### PR TITLE
chore: sanitize log entries

### DIFF
--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -664,7 +664,8 @@ namespace garge_operator.Services
                     // Check if the desired state differs from the current state
                     if (_lastPublishedSwitchStates.TryGetValue(topic, out var currentState) && currentState == payload)
                     {
-                        _logger.LogInformation($"Skipping publish for topic '{topic}' as the state '{payload}' is unchanged.");
+                        var sanitizedPayload = payload.Replace("\r", "").Replace("\n", "");
+                        _logger.LogInformation($"Skipping publish for topic '{topic}' as the state '{sanitizedPayload}' is unchanged.");
                         return;
                     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/sondresjolyst/garge-operator/security/code-scanning/3](https://github.com/sondresjolyst/garge-operator/security/code-scanning/3)

To fix this issue, we should sanitize the `payload` variable before logging it in the log entry on line 667 of `Services/MqttService.cs`. Since the logs are in plain text, the best approach is to remove or replace newline (`\n`, `\r\n`, `\r`) and other control characters from the input before including it in the log message. This can be done using `String.Replace` or a regular expression to strip all line breaks. The fix should be localized to the log entry, so that only the data being logged is sanitized, without changing the actual application logic or the value being published.

Specifically:
- In `PublishSwitchDataAsync`, before logging, create a "sanitized" version of `payload` for the log entry.
- Use `payload.Replace("\r", "").Replace("\n", "")` or a regex to remove line breaks.
- Use the sanitized version in `_logger.LogInformation(...)`.
- No new imports are needed if we use simple string replacements.

Only the code of the log entry needs to be changed, not the actual use of `payload` elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
