### PR TITLE
chore: sanitize log entries

### DIFF
--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -771,7 +771,9 @@ namespace garge_operator.Services
                 if (_switchUniqIds.TryGetValue(switchName, out var switchUniqId))
                 {
                     await PublishSwitchDataAsync(topic, state);
-                    _logger.LogInformation($"Published switch state '{state}' to topic '{topic}'.");
+                    var sanitizedState = state.Replace("\r", "").Replace("\n", "");
+                    var sanitizedTopic = topic.Replace("\r", "").Replace("\n", "");
+                    _logger.LogInformation($"Published switch state '{sanitizedState}' to topic '{sanitizedTopic}'.");
                 }
                 else
                 {


### PR DESCRIPTION
Potential fix for [https://github.com/sondresjolyst/garge-operator/security/code-scanning/2](https://github.com/sondresjolyst/garge-operator/security/code-scanning/2)

The problem is that user-supplied values (`state` and potentially `topic`, since it contains `switchName` from user input) are being logged without sanitization. To fix this, we should remove newlines and other potentially problematic characters from these values before logging. The simplest approach is to use `String.Replace` to remove or replace `\r` and `\n` for both `state` and `topic` before including them in log entries. This should be done only for the log messages (not for the actual values used elsewhere in the business logic), to avoid unintended side effects.

The change should be made in `Services/MqttService.cs` at the log line:
- On line 774, sanitize both `state` and `topic` before logging.

No new methods are required, only a call to `.Replace()` on those variables before logging. No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
