### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -762,7 +762,9 @@ namespace garge_operator.Services
                 {
                     if (_recentlyPublishedStates.Contains($"{topic}:{state}"))
                     {
-                        _logger.LogInformation($"Ignoring self-triggered event for topic '{topic}' with state '{state}'.");
+                        var sanitizedState = state.Replace("\r", "").Replace("\n", "");
+                        var sanitizedTopic = topic.Replace("\r", "").Replace("\n", "");
+                        _logger.LogInformation($"Ignoring self-triggered event for topic '{sanitizedTopic}' with state '{sanitizedState}'.");
                         _recentlyPublishedStates.Remove($"{topic}:{state}");
                         return;
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/sondresjolyst/garge-operator/security/code-scanning/1](https://github.com/sondresjolyst/garge-operator/security/code-scanning/1)

To fix this issue, sanitize all user-controllable values before they are included in log entries. Specifically, before logging the interpolated message on line 765, ensure that both `topic` and `state` have newline and carriage return characters removed, just as is already done before logging on line 776 (`sanitizedState` and `sanitizedTopic`). Create sanitized versions of these variables and use them in the log message. This change should be made in the `HandleWebhookDataAsync` method in `Services/MqttService.cs`. No additional methods or imports are needed, as string replacement is already in use elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
