### PR TITLE
fix: seed battery health sensor tracking on operator startup

### DIFF
--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -103,6 +103,14 @@ namespace garge_operator.Services
             // Get all sensors from the API
             _sensors = await GetAllSensorsAsync(token);
 
+            // Seed battery health sensor tracking from pre-existing sensors so they
+            // are routed correctly after an operator restart (without waiting for a new config message).
+            foreach (var s in _sensors.Where(s => s.Type == "battery"))
+            {
+                _batteryHealthUniqIds.Add(s.Name);
+                _sensorUniqIds[s.Name] = s.Name;
+            }
+
             // Get all switches from the API
             _switches = await GetAllSwitchesAsync(token);
 


### PR DESCRIPTION
## Problem
After an operator restart, `_batteryHealthUniqIds` was empty until each device re-published a config MQTT message. Battery health state messages were silently ignored until then.

## Changes
- **`MqttService.ConnectAsync`** - pre-populates `_batteryHealthUniqIds` and `_sensorUniqIds` for all `Type == battery` sensors loaded from the API on startup