### PR TITLE
feat(automations): timed auto-off logic in worker

### DIFF
--- a/Dtos/Automation/AutomationRuleDto.cs
+++ b/Dtos/Automation/AutomationRuleDto.cs
@@ -15,5 +15,7 @@
         public double? ElectricityPriceThreshold { get; set; }
         public string? ElectricityPriceArea { get; set; }
         public string? ElectricityPriceOperator { get; set; }
+        public double? TimerDurationHours { get; set; }
+        public DateTime? TimerActivatedAt { get; set; }
     }
 }

--- a/Worker.cs
+++ b/Worker.cs
@@ -101,9 +101,21 @@ public class Worker : BackgroundService
                     }
                     else
                     {
-                        // Timer still active — re-enforce ON in case MQTT state was lost
-                        _logger.LogInformation("Startup: timer still active for rule {RuleId}, re-enforcing ON.", rule.Id);
-                        await _mqttService.PublishSwitchDataAsync(topic, "on");
+                        // Timer still active — re-enforce state, gated by price condition if set
+                        bool priceOk = true;
+                        if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
+                            rule.ElectricityPriceThreshold.HasValue &&
+                            !string.IsNullOrEmpty(rule.ElectricityPriceArea))
+                        {
+                            var price = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
+                            if (price.HasValue)
+                                priceOk = EvaluateCondition(price.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold.Value);
+                        }
+
+                        var startupDesired = priceOk ? "on" : "off";
+                        _logger.LogInformation("Startup: timer active for rule {RuleId}, enforcing '{Action}' (priceOk={PriceOk}).", rule.Id, startupDesired, priceOk);
+                        await _mqttService.PublishSwitchDataAsync(topic, startupDesired);
+                        _lastPublishedActions[rule.TargetId] = startupDesired;
                     }
                 }
                 // If TimerActivatedAt is null the rule is idle — no action needed on startup
@@ -188,7 +200,25 @@ public class Worker : BackgroundService
                     }
                     else
                     {
-                        _logger.LogInformation("Rule {RuleId}: timer still running ({Elapsed:hh\\:mm} / {Duration}h), skipping.", rule.Id, elapsed, rule.TimerDurationHours.Value);
+                        // Timer still running — gate socket by price condition (sensor is trigger-only)
+                        bool priceOk = true;
+                        if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
+                            rule.ElectricityPriceThreshold.HasValue &&
+                            !string.IsNullOrEmpty(rule.ElectricityPriceArea))
+                        {
+                            var price = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
+                            if (price.HasValue)
+                                priceOk = EvaluateCondition(price.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold.Value);
+                        }
+
+                        var desired = priceOk ? "on" : "off";
+                        var last = _lastPublishedActions.GetValueOrDefault(rule.TargetId);
+                        if (last != desired)
+                        {
+                            _logger.LogInformation("Rule {RuleId}: timer running, price gate changed → '{Action}'.", rule.Id, desired);
+                            await _mqttService.PublishSwitchDataAsync(topic, desired);
+                            _lastPublishedActions[rule.TargetId] = desired;
+                        }
                     }
                     continue;
                 }

--- a/Worker.cs
+++ b/Worker.cs
@@ -31,6 +31,16 @@ public class Worker : BackgroundService
     {
         await _mqttService.ConnectAsync();
 
+        // Reconcile rule state on startup before entering the poll loop
+        try
+        {
+            await ReconcileOnStartupAsync(stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during startup reconciliation.");
+        }
+
         var lastAutomationPoll = DateTimeOffset.MinValue;
 
         while (!stoppingToken.IsCancellationRequested)
@@ -54,29 +64,87 @@ public class Worker : BackgroundService
         }
     }
 
+    /// <summary>
+    /// On startup: immediately resolve any expired timers, re-enforce active timers,
+    /// and set correct state for non-timed rules — handles the operator-was-down case.
+    /// </summary>
+    private async Task ReconcileOnStartupAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Running startup reconciliation pass.");
+
+        var (client, rules) = await FetchRulesAsync(stoppingToken);
+        if (client == null || rules == null) return;
+
+        var apiBaseUrl = _configuration["Api:BaseUrl"]!;
+
+        foreach (var rule in rules)
+        {
+            if (!string.Equals(rule.TargetType, "Switch", StringComparison.OrdinalIgnoreCase) || !rule.IsEnabled)
+                continue;
+
+            var targetSwitch = GetSwitch(rule.TargetId);
+            if (targetSwitch == null) continue;
+
+            var topic = $"garge/devices/{targetSwitch.Name}/set";
+
+            if (rule.TimerDurationHours.HasValue)
+            {
+                if (rule.TimerActivatedAt.HasValue)
+                {
+                    var elapsed = DateTime.UtcNow - rule.TimerActivatedAt.Value.ToUniversalTime();
+                    if (elapsed >= TimeSpan.FromHours(rule.TimerDurationHours.Value))
+                    {
+                        // Timer expired while operator was down — turn OFF and clear
+                        _logger.LogInformation("Startup: timer expired for rule {RuleId}, turning OFF and clearing.", rule.Id);
+                        await _mqttService.PublishSwitchDataAsync(topic, "off");
+                        await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{rule.Id}/timer-clear", stoppingToken);
+                    }
+                    else
+                    {
+                        // Timer still active — re-enforce ON in case MQTT state was lost
+                        _logger.LogInformation("Startup: timer still active for rule {RuleId}, re-enforcing ON.", rule.Id);
+                        await _mqttService.PublishSwitchDataAsync(topic, "on");
+                    }
+                }
+                // If TimerActivatedAt is null the rule is idle — no action needed on startup
+            }
+            else
+            {
+                // Non-timed rule: evaluate condition and enforce correct state
+                var sensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
+                if (sensorValue == null) continue;
+
+                bool conditionMet = EvaluateSensorCondition(sensorValue.Value, rule.Condition, rule.Threshold);
+
+                if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
+                    rule.ElectricityPriceThreshold.HasValue &&
+                    !string.IsNullOrEmpty(rule.ElectricityPriceArea))
+                {
+                    var price = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
+                    if (price.HasValue)
+                    {
+                        var priceConditionMet = EvaluateCondition(price.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold!.Value);
+                        var logicalOp = (rule.ElectricityPriceOperator ?? "AND").ToUpperInvariant();
+                        conditionMet = logicalOp == "OR" ? conditionMet || priceConditionMet : conditionMet && priceConditionMet;
+                    }
+                }
+
+                var desiredAction = conditionMet ? rule.Action.ToLowerInvariant() : (rule.Action.ToLowerInvariant() == "on" ? "off" : "on");
+                _logger.LogInformation("Startup: enforcing '{Action}' for non-timed rule {RuleId}.", desiredAction, rule.Id);
+                await _mqttService.PublishSwitchDataAsync(topic, desiredAction);
+                _lastPublishedActions[rule.TargetId] = desiredAction;
+            }
+        }
+
+        _logger.LogInformation("Startup reconciliation complete.");
+    }
+
     private async Task PollAutomationsAsync(CancellationToken stoppingToken)
     {
-        var client = _httpClientFactory.CreateClient();
-        var apiBaseUrl = _configuration["Api:BaseUrl"];
-        var token = await _mqttService.GetJwtTokenAsync();
-        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        var (client, rules) = await FetchRulesAsync(stoppingToken);
+        if (client == null || rules == null) return;
 
-        // Get automation rules
-        var response = await client.GetAsync($"{apiBaseUrl}/api/automation", stoppingToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogError("Failed to fetch automation rules. Status: {StatusCode}", response.StatusCode);
-            return;
-        }
-
-        var json = await response.Content.ReadAsStringAsync(stoppingToken);
-        var doc = JsonDocument.Parse(json);
-        var rules = JsonSerializer.Deserialize<List<AutomationRuleDto>>(doc.RootElement.GetRawText(), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-        if (rules == null)
-        {
-            _logger.LogWarning("No automation rules found.");
-            return;
-        }
+        var apiBaseUrl = _configuration["Api:BaseUrl"]!;
 
         _logger.LogInformation("Loaded {Count} automation rules.", rules.Count);
 
@@ -96,140 +164,179 @@ public class Worker : BackgroundService
                 continue;
             }
 
-            // Get latest sensor value
-            var sensorResponse = await client.GetAsync($"{apiBaseUrl}/api/sensors/{rule.SensorId}/latest-data", stoppingToken);
-            if (!sensorResponse.IsSuccessStatusCode)
-            {
-                _logger.LogWarning("Failed to fetch latest data for sensor {SensorId}. Status: {StatusCode}", rule.SensorId, sensorResponse.StatusCode);
-                continue;
-            }
-
-            var sensorJson = await sensorResponse.Content.ReadAsStringAsync(stoppingToken);
-            var sensorData = JsonDocument.Parse(sensorJson).RootElement;
-            var valueStr = sensorData.GetProperty("value").GetString();
-            if (!double.TryParse(valueStr, out var sensorValue))
-            {
-                _logger.LogWarning("Could not parse sensor value '{Value}' for sensor {SensorId}.", valueStr, rule.SensorId);
-                continue;
-            }
-
-            _logger.LogInformation("Evaluating rule {RuleId}: sensorValue={SensorValue}, condition={Condition}, threshold={Threshold}, action={Action}", rule.Id, sensorValue, rule.Condition, rule.Threshold, rule.Action);
-
-            // Evaluate sensor condition
-            bool sensorConditionMet = rule.Condition switch
-            {
-                "<" => sensorValue < rule.Threshold,
-                ">" => sensorValue > rule.Threshold,
-                "<=" => sensorValue <= rule.Threshold,
-                ">=" => sensorValue >= rule.Threshold,
-                "==" => sensorValue == rule.Threshold,
-                "!=" => sensorValue != rule.Threshold,
-                _ => false
-            };
-
-            _logger.LogInformation("Rule {RuleId} sensorConditionMet={ConditionMet}", rule.Id, sensorConditionMet);
-
-            // Evaluate optional electricity price condition
-            bool conditionMet = sensorConditionMet;
-            if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
-                rule.ElectricityPriceThreshold.HasValue &&
-                !string.IsNullOrEmpty(rule.ElectricityPriceArea))
-            {
-                var currentPrice = await GetCurrentPriceAsync(client, apiBaseUrl!, rule.ElectricityPriceArea, stoppingToken);
-                if (currentPrice.HasValue)
-                {
-                    bool priceConditionMet = rule.ElectricityPriceCondition switch
-                    {
-                        "<" => currentPrice.Value < rule.ElectricityPriceThreshold.Value,
-                        ">" => currentPrice.Value > rule.ElectricityPriceThreshold.Value,
-                        "<=" => currentPrice.Value <= rule.ElectricityPriceThreshold.Value,
-                        ">=" => currentPrice.Value >= rule.ElectricityPriceThreshold.Value,
-                        "==" => currentPrice.Value == rule.ElectricityPriceThreshold.Value,
-                        _ => false
-                    };
-
-                    _logger.LogInformation("Rule {RuleId} priceConditionMet={PriceConditionMet} (price={Price}, condition={Cond}, threshold={Threshold})",
-                        rule.Id, priceConditionMet, currentPrice.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold.Value);
-
-                    var logicalOp = (rule.ElectricityPriceOperator ?? "AND").ToUpperInvariant();
-                    conditionMet = logicalOp == "OR"
-                        ? sensorConditionMet || priceConditionMet
-                        : sensorConditionMet && priceConditionMet;
-                }
-                else
-                {
-                    _logger.LogWarning("Rule {RuleId}: could not fetch electricity price for area {Area}, skipping.", rule.Id, rule.ElectricityPriceArea);
-                    continue;
-                }
-            }
-
-            _logger.LogInformation("Rule {RuleId} conditionMet={ConditionMet}", rule.Id, conditionMet);
-
-            if (!conditionMet)
-            {
-                _logger.LogInformation("Rule {RuleId} condition not met. Skipping.", rule.Id);
-                continue;
-            }
-
-            // Find switch name by TargetId
-            var switchObj = _mqttService
-                .GetType()
-                .GetField("_switches", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
-                .GetValue(_mqttService) as List<Switch>;
-            if (switchObj == null)
-            {
-                _logger.LogWarning("Could not access _switches list in MqttService.");
-                continue;
-            }
-            var targetSwitch = switchObj.FirstOrDefault(s => s.Id == rule.TargetId);
-
+            var targetSwitch = GetSwitch(rule.TargetId);
             if (targetSwitch == null)
             {
                 _logger.LogWarning("Switch with ID {TargetId} not found in local list.", rule.TargetId);
                 continue;
             }
-            else
-            {
-                _logger.LogInformation("Found switch {SwitchName} (ID: {TargetId}) for rule {RuleId}.", targetSwitch.Name, rule.TargetId, rule.Id);
-            }
 
             var topic = $"garge/devices/{targetSwitch.Name}/set";
-            var action = rule.Action.ToLowerInvariant();
 
-            // Check current state from MqttService
-            var currentStateDict = _mqttService.LastPublishedSwitchStates;
-            var currentState = currentStateDict.TryGetValue(targetSwitch.Name, out var state) ? state.ToLowerInvariant() : null;
-
-            // Only publish if action is different from current state
-            if (currentState == action)
+            // ── Timed rule handling ───────────────────────────────────────────
+            if (rule.TimerDurationHours.HasValue)
             {
-                _logger.LogInformation("Skipping publish for switch {SwitchName} (ID: {TargetId}) as action '{Action}' is unchanged (actual state: {CurrentState}).", targetSwitch.Name, rule.TargetId, action, currentState);
+                if (rule.TimerActivatedAt.HasValue)
+                {
+                    var elapsed = DateTime.UtcNow - rule.TimerActivatedAt.Value.ToUniversalTime();
+                    if (elapsed >= TimeSpan.FromHours(rule.TimerDurationHours.Value))
+                    {
+                        _logger.LogInformation("Rule {RuleId}: timer elapsed ({Elapsed:hh\\:mm}), turning OFF.", rule.Id, elapsed);
+                        await _mqttService.PublishSwitchDataAsync(topic, "off");
+                        _lastPublishedActions[rule.TargetId] = "off";
+                        await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{rule.Id}/timer-clear", stoppingToken);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Rule {RuleId}: timer still running ({Elapsed:hh\\:mm} / {Duration}h), skipping.", rule.Id, elapsed, rule.TimerDurationHours.Value);
+                    }
+                    continue;
+                }
+
+                // Timer is idle — check trigger condition
+                var sensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
+                if (sensorValue == null) continue;
+
+                bool conditionMet = EvaluateSensorCondition(sensorValue.Value, rule.Condition, rule.Threshold);
+                conditionMet = await CombineWithPriceConditionAsync(client, apiBaseUrl, rule, conditionMet, stoppingToken);
+
+                if (conditionMet)
+                {
+                    _logger.LogInformation("Rule {RuleId}: condition met, starting {Duration}h timer, turning ON.", rule.Id, rule.TimerDurationHours.Value);
+                    await _mqttService.PublishSwitchDataAsync(topic, "on");
+                    _lastPublishedActions[rule.TargetId] = "on";
+                    await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{rule.Id}/timer-start", stoppingToken);
+                    await MarkTriggeredAsync(client, apiBaseUrl, rule.Id, stoppingToken);
+                }
                 continue;
             }
 
-            _logger.LogInformation("Publishing action '{Action}' to switch {SwitchName} (ID: {TargetId}) due to automation rule {RuleId}.", action, targetSwitch.Name, rule.TargetId, rule.Id);
+            // ── Standard (non-timed) rule handling ───────────────────────────
+            var stdSensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
+            if (stdSensorValue == null) continue;
+
+            bool stdConditionMet = EvaluateSensorCondition(stdSensorValue.Value, rule.Condition, rule.Threshold);
+            stdConditionMet = await CombineWithPriceConditionAsync(client, apiBaseUrl, rule, stdConditionMet, stoppingToken);
+
+            _logger.LogInformation("Rule {RuleId} conditionMet={ConditionMet}", rule.Id, stdConditionMet);
+
+            if (!stdConditionMet)
+            {
+                _logger.LogInformation("Rule {RuleId} condition not met. Skipping.", rule.Id);
+                continue;
+            }
+
+            var action = rule.Action.ToLowerInvariant();
+            var currentStateDict = _mqttService.LastPublishedSwitchStates;
+            var currentState = currentStateDict.TryGetValue(targetSwitch.Name, out var state) ? state.ToLowerInvariant() : null;
+
+            if (currentState == action)
+            {
+                _logger.LogInformation("Skipping publish for switch {SwitchName} as action '{Action}' is unchanged.", targetSwitch.Name, action);
+                continue;
+            }
+
+            _logger.LogInformation("Publishing action '{Action}' to switch {SwitchName} due to rule {RuleId}.", action, targetSwitch.Name, rule.Id);
             await _mqttService.PublishSwitchDataAsync(topic, action);
             _lastPublishedActions[rule.TargetId] = action;
-            _logger.LogInformation("Published action '{Action}' to switch {SwitchName} (ID: {TargetId}) due to automation rule {RuleId}.", action, targetSwitch.Name, rule.TargetId, rule.Id);
-
-            try
-            {
-                var triggeredResponse = await client.PatchAsync($"{apiBaseUrl}/api/automation/{rule.Id}/triggered", null, stoppingToken);
-                if (!triggeredResponse.IsSuccessStatusCode)
-                    _logger.LogWarning("Failed to mark rule {RuleId} as triggered. Status: {StatusCode}", rule.Id, triggeredResponse.StatusCode);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Could not update LastTriggeredAt for rule {RuleId}.", rule.Id);
-            }
+            await MarkTriggeredAsync(client, apiBaseUrl, rule.Id, stoppingToken);
         }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient? Client, List<AutomationRuleDto>? Rules)> FetchRulesAsync(CancellationToken stoppingToken)
+    {
+        var client = _httpClientFactory.CreateClient();
+        var apiBaseUrl = _configuration["Api:BaseUrl"];
+        var token = await _mqttService.GetJwtTokenAsync();
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync($"{apiBaseUrl}/api/automation", stoppingToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed to fetch automation rules. Status: {StatusCode}", response.StatusCode);
+            return (null, null);
+        }
+
+        var json = await response.Content.ReadAsStringAsync(stoppingToken);
+        var rules = JsonSerializer.Deserialize<List<AutomationRuleDto>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        if (rules == null)
+        {
+            _logger.LogWarning("No automation rules found.");
+            return (null, null);
+        }
+
+        return (client, rules);
+    }
+
+    private Switch? GetSwitch(int targetId)
+    {
+        var switches = _mqttService
+            .GetType()
+            .GetField("_switches", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
+            .GetValue(_mqttService) as List<Switch>;
+        return switches?.FirstOrDefault(s => s.Id == targetId);
+    }
+
+    private async Task<double?> GetSensorValueAsync(HttpClient client, string apiBaseUrl, int sensorId, CancellationToken stoppingToken)
+    {
+        var sensorResponse = await client.GetAsync($"{apiBaseUrl}/api/sensors/{sensorId}/latest-data", stoppingToken);
+        if (!sensorResponse.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to fetch latest data for sensor {SensorId}. Status: {StatusCode}", sensorId, sensorResponse.StatusCode);
+            return null;
+        }
+
+        var sensorJson = await sensorResponse.Content.ReadAsStringAsync(stoppingToken);
+        var valueStr = JsonDocument.Parse(sensorJson).RootElement.GetProperty("value").GetString();
+        if (!double.TryParse(valueStr, out var sensorValue))
+        {
+            _logger.LogWarning("Could not parse sensor value '{Value}' for sensor {SensorId}.", valueStr, sensorId);
+            return null;
+        }
+
+        return sensorValue;
+    }
+
+    private static bool EvaluateSensorCondition(double value, string condition, double threshold)
+        => EvaluateCondition(value, condition, threshold);
+
+    private static bool EvaluateCondition(double value, string condition, double threshold) => condition switch
+    {
+        "<"  => value < threshold,
+        ">"  => value > threshold,
+        "<=" => value <= threshold,
+        ">=" => value >= threshold,
+        "==" => value == threshold,
+        "!=" => value != threshold,
+        _    => false
+    };
+
+    private async Task<bool> CombineWithPriceConditionAsync(HttpClient client, string apiBaseUrl, AutomationRuleDto rule, bool sensorConditionMet, CancellationToken stoppingToken)
+    {
+        if (string.IsNullOrEmpty(rule.ElectricityPriceCondition) ||
+            !rule.ElectricityPriceThreshold.HasValue ||
+            string.IsNullOrEmpty(rule.ElectricityPriceArea))
+            return sensorConditionMet;
+
+        var currentPrice = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
+        if (!currentPrice.HasValue)
+        {
+            _logger.LogWarning("Rule {RuleId}: could not fetch electricity price for area {Area}, skipping.", rule.Id, rule.ElectricityPriceArea);
+            return false;
+        }
+
+        var priceConditionMet = EvaluateCondition(currentPrice.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold.Value);
+        _logger.LogInformation("Rule {RuleId} priceConditionMet={Met} (price={Price})", rule.Id, priceConditionMet, currentPrice.Value);
+
+        var logicalOp = (rule.ElectricityPriceOperator ?? "AND").ToUpperInvariant();
+        return logicalOp == "OR" ? sensorConditionMet || priceConditionMet : sensorConditionMet && priceConditionMet;
     }
 
     private async Task<double?> GetCurrentPriceAsync(HttpClient client, string apiBaseUrl, string area, CancellationToken stoppingToken)
     {
         var now = DateTime.UtcNow;
-
-        // Return cached value if still valid for current delivery hour
         if (_priceCache.TryGetValue(area, out var cached) && cached.ValidUntil > now)
             return cached.Value;
 
@@ -256,4 +363,21 @@ public class Worker : BackgroundService
             return null;
         }
     }
+
+    private async Task CallApiPatchAsync(HttpClient client, string url, CancellationToken stoppingToken)
+    {
+        try
+        {
+            var response = await client.PatchAsync(url, null, stoppingToken);
+            if (!response.IsSuccessStatusCode)
+                _logger.LogWarning("PATCH {Url} failed with status {StatusCode}.", url, response.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not PATCH {Url}.", url);
+        }
+    }
+
+    private async Task MarkTriggeredAsync(HttpClient client, string apiBaseUrl, int ruleId, CancellationToken stoppingToken)
+        => await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{ruleId}/triggered", stoppingToken);
 }


### PR DESCRIPTION
## Summary

Implements timed auto-off logic in the automation worker.

### Startup reconciliation
On every restart the worker immediately resolves any timer state that changed while it was down:
- Elapsed timers: publish off + call timer-clear
- Active timers: re-publish on to restore MQTT state in case it was lost
- Non-timed rules: evaluate condition and enforce correct socket state

### Poll loop changes
- Active timer + elapsed -> publish off, call timer-clear
- Active timer + still running -> skip (do not re-evaluate condition)
- No active timer + condition met -> publish on, call timer-start
- No TimerDurationHours -> existing behaviour unchanged

Depends on: https://github.com/sondresjolyst/garge-api/pull/87
