### PR TITLE
fix(worker): accept any switch type as automation target

### DIFF
--- a/Worker.cs
+++ b/Worker.cs
@@ -79,7 +79,7 @@ public class Worker : BackgroundService
 
         foreach (var rule in rules)
         {
-            if (!string.Equals(rule.TargetType, "Switch", StringComparison.OrdinalIgnoreCase) || !rule.IsEnabled)
+            if (!rule.IsEnabled)
                 continue;
 
             var targetSwitch = GetSwitch(rule.TargetId);
@@ -163,12 +163,6 @@ public class Worker : BackgroundService
         foreach (var rule in rules)
         {
             _logger.LogInformation("Automation Rule: {Rule}", JsonSerializer.Serialize(rule));
-
-            if (!string.Equals(rule.TargetType, "Switch", StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogInformation("Skipping rule {RuleId} because TargetType is not 'Switch'.", rule.Id);
-                continue;
-            }
 
             if (!rule.IsEnabled)
             {


### PR DESCRIPTION
## Problem
Automation rule 5 was silently skipped with:
```
Skipping rule 5 because TargetType is not 'Switch'.
```

The rule's target switch has `TargetType: "SOCKET"` — set by the API after the switch-type migration — but the operator hardcoded a check for the string `"Switch"`.

Other rules (2, 3) worked because their target switches still carry the old `TargetType: "switch"` value.

## Root cause
A hardcoded `string.Equals(rule.TargetType, "Switch", OrdinalIgnoreCase)` guard was filtering out any rule whose target type wasn't exactly `"switch"`. This broke when the API started storing sockets with type `"SOCKET"`.

## Fix
Remove the `TargetType` string check entirely. `GetSwitch(rule.TargetId)` returning non-null is the correct validity gate — if the target exists in the switches list, it is actionable regardless of its type string.
