### PR TITLE
fix: automation socket target type (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.4.1](https://github.com/sondresjolyst/garge-operator/compare/v1.4.0...v1.4.1) (2026-04-16)
+
+
+### Bug Fixes
+
+* automation socket target type ([#63](https://github.com/sondresjolyst/garge-operator/issues/63)) ([c8f5804](https://github.com/sondresjolyst/garge-operator/commit/c8f5804adc3e34c7490529fc54b28089eb93eef7))
+* **worker:** accept any switch type as automation target ([#62](https://github.com/sondresjolyst/garge-operator/issues/62)) ([630d6c9](https://github.com/sondresjolyst/garge-operator/commit/630d6c9e0030a57a8ff27590f63c068fb5c912c8))
+
+## [1.4.0](https://github.com/sondresjolyst/garge-operator/compare/v1.3.0...v1.4.0) (2026-04-14)
+
+
+### Features
+
+* **automations:** evaluate electricity price conditions in worker ([#57](https://github.com/sondresjolyst/garge-operator/issues/57)) ([a96649c](https://github.com/sondresjolyst/garge-operator/commit/a96649c52ef468aa9bb6c1dd0c41577cc3394a1d))
+* **automations:** timed auto-off logic in worker ([#58](https://github.com/sondresjolyst/garge-operator/issues/58)) ([f8fb44d](https://github.com/sondresjolyst/garge-operator/commit/f8fb44d8929c8a8c7befe3e66cde6a525798ad9c))
+
 ## [1.3.0](https://github.com/sondresjolyst/garge-operator/compare/v1.2.4...v1.3.0) (2026-04-10)
 
 

--- a/Worker.cs
+++ b/Worker.cs
@@ -85,7 +85,7 @@ public class Worker : BackgroundService
             var targetSwitch = GetSwitch(rule.TargetId);
             if (targetSwitch == null) continue;
 
-            if (!new[] { "switch", "socket" }.Contains(targetSwitch.Type, StringComparer.OrdinalIgnoreCase))
+            if (!new[] { "socket" }.Contains(targetSwitch.Type, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogInformation("Skipping rule {RuleId}: switch type '{Type}' is not actionable.", rule.Id, targetSwitch.Type);
                 continue;
@@ -183,7 +183,7 @@ public class Worker : BackgroundService
                 continue;
             }
 
-            if (!new[] { "switch", "socket" }.Contains(targetSwitch.Type, StringComparer.OrdinalIgnoreCase))
+            if (!new[] { "socket" }.Contains(targetSwitch.Type, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogInformation("Skipping rule {RuleId}: switch type '{Type}' is not actionable.", rule.Id, targetSwitch.Type);
                 continue;


### PR DESCRIPTION
* Development (#55)

* feat: skip disabled automation rules and record last triggered timestamp (#50)

- AutomationRuleDto: add IsEnabled field
- Worker: skip rules where IsEnabled is false
- Worker: call PATCH /api/automation/{id}/triggered after successful publish

* ci: release please

* ci: release please

* chore(main): release 1.4.0 (#61)



* fix(worker): accept any switch type as automation target

The TargetType check hardcoded 'Switch', causing rules whose target was created with type 'SOCKET' (post-API migration) to be silently skipped.

Older switches have TargetType='switch', newer ones have TargetType='SOCKET'. Rather than enumerating type strings, drop the check entirely and rely on GetSwitch() returning non-null as the validity gate — if the target exists in the switches list, it is actionable regardless of its type string.

* fix(worker): restore actionable-type guard using switch's own Type field

Re-add the TargetType guard that was removed in the PR fix, but check targetSwitch.Type (the live device type) instead of rule.TargetType (the potentially stale string on the rule DTO).

Only 'SOCKET' is accepted. SHRGBC and any unknown types are excluded as automation rules are only supported for socket devices.

* chore(main): release 1.4.1 (#65)



---------