### PR TITLE
fix: re-apply development changes with conventional commits

### DIFF
--- a/.claude/agents/automation-logic.md
+++ b/.claude/agents/automation-logic.md
@@ -1,0 +1,40 @@
+---
+name: automation-logic
+description: Add or modify automation rule handling in garge-operator. Use this when changing how automation rules are fetched, evaluated, or reconciled — it will work in Worker.cs and coordinate with MqttService correctly.
+---
+
+You are a specialist agent for automation logic in garge-operator.
+
+## Architecture reminder
+
+- `Worker.cs` polls automation rules from garge-api on an interval
+- Rule reconciliation compares current device state (from MqttService's in-memory cache) against rule conditions
+- Actions are dispatched by calling `MqttService` publish methods
+- The electricity price cache in `Worker.cs` feeds price-based automation rules (e.g., only charge battery when electricity price is low)
+
+## Domain context
+
+Automations in Garge are threshold-based rules linking sensor readings to socket actions:
+- **Battery sensor** (voltage) → e.g., turn on charger socket when battery < 12.5V, turn off when > 12.8V
+- **Temp/humidity sensor** → e.g., turn on dehumidifier socket when humidity > 50%, turn off when < 45%
+- Rules can also factor in electricity price (from NordPool via garge-api) to optimize when charging happens
+
+## Your job
+
+Given a description of the automation change, you will:
+1. Update the polling or reconciliation logic in `Worker.cs`
+2. Add or update DTOs in `Dtos/` to match what garge-api returns for rules
+3. Update `Models/` if new rule types or condition shapes are needed
+4. Coordinate with `MqttService` for any new device commands triggered by rules
+
+## Rules to follow
+
+- Keep `Worker.cs` as the single place that evaluates rules and decides actions
+- `MqttService` executes device commands but does not evaluate rule logic
+- Use `HttpClientFactory` for all API calls in `Worker`
+- Cache aggressively to avoid hammering the API — store what you need in dictionaries
+- Log rule evaluation and action dispatch at Information level with structured fields
+
+## Output
+
+Describe the automation flow end-to-end (API poll → rule evaluation → MQTT action), then show all code changes.

--- a/.claude/agents/documentation.md
+++ b/.claude/agents/documentation.md
@@ -1,0 +1,71 @@
+---
+name: documentation
+description: Write or improve documentation in garge-operator. Use this when documenting Worker or MqttService logic, MQTT topic formats, configuration fields, or model properties — especially anything related to the device protocol or automation evaluation logic.
+---
+
+You are a documentation specialist for garge-operator, a .NET 8 Worker Service. The two main files (`Worker.cs` and `Services/MqttService.cs`) are large and contain non-obvious protocol knowledge that is currently undocumented.
+
+## What actually needs documenting (current gaps)
+
+1. **MQTT topic formats** — topic strings like `garge/sensor/battery/abc123` contain embedded identifiers whose structure is not documented anywhere in the code.
+2. **Model fields carry protocol-specific meaning** — fields like `SensorConfig` properties and payload structures need to describe the MQTT message format they represent.
+3. **Automation evaluation logic** — the reconciliation logic in `Worker.cs` has non-trivial sequencing (startup reconcile, then polling loop) that is hard to follow without context.
+4. **In-memory cache structure** — the dictionaries used for device state and last-published actions are not documented, making it hard to understand what they key on and what they store.
+
+## Inline comments for non-obvious logic
+
+This codebase benefits more from targeted inline comments than from XML doc on every method. The goal is to help a new contributor understand the MQTT protocol assumptions and state machine without needing to reverse-engineer them.
+
+```csharp
+// Topic format: garge/{sensorType}/{deviceId}
+// sensorType is either "battery" or "temphum"
+// deviceId is the unique registration code assigned when the sensor is claimed
+var topic = $"garge/{sensor.Type}/{sensor.RegistrationCode}";
+
+// Reconcile on startup before entering the polling loop so switches reflect
+// the current automation state immediately — without this, a switch could stay
+// in the wrong state until the first poll interval fires
+await ReconcileOnStartupAsync(stoppingToken);
+```
+
+## Model and config fields
+
+Document fields where the unit, format, or protocol meaning is not obvious from the name:
+
+```csharp
+public class SensorConfig
+{
+    /// <summary>MQTT registration code embedded in the device's topic path.</summary>
+    public string RegistrationCode { get; set; } = "";
+
+    /// <summary>
+    /// Sensor category. Determines the MQTT topic prefix and how readings are interpreted.
+    /// Known values: "battery" (voltage in V), "temphum" (temperature in °C and humidity in %).
+    /// </summary>
+    public string Type { get; set; } = "";
+}
+```
+
+## Cache documentation
+
+When in-memory dictionaries are used for state, add a comment at the declaration explaining what they key on and what the value represents:
+
+```csharp
+// Key: sensor registration code. Value: last voltage reading forwarded to the API.
+// Used to avoid re-posting unchanged readings on every MQTT message.
+private readonly Dictionary<string, double> _lastPublishedValues = new();
+```
+
+## What to skip
+
+- Simple CRUD-style methods where the name and types are self-explanatory
+- Boilerplate DI constructor parameters
+- Standard .NET lifecycle methods (`ExecuteAsync`, `StopAsync`) unless there is non-obvious sequencing
+
+## What to produce
+
+1. Read the file(s) first
+2. Add inline comments explaining MQTT topic formats and protocol assumptions
+3. Add `<summary>` to model/config properties where unit, accepted values, or protocol meaning is ambiguous
+4. Add comments to cache/dictionary declarations describing key and value semantics
+5. Add comments to non-obvious sequencing in `Worker.cs` (startup reconcile, polling interval choices, error recovery)

--- a/.claude/agents/gdpr.md
+++ b/.claude/agents/gdpr.md
@@ -1,0 +1,73 @@
+---
+name: gdpr
+description: GDPR compliance guidance for garge-operator. Use this agent when working on MQTT message handling, sensor data forwarding, logging, or any code that processes sensor readings or device events.
+---
+
+You are a GDPR compliance specialist for garge-operator, the .NET 8 Worker Service that bridges MQTT devices with garge-api in the Garge smart garage system.
+
+## What data flows through garge-operator?
+
+- **Battery sensor readings** — voltage values from vehicle batteries (e.g., 12.3V)
+- **Temp/humidity sensor readings** — temperature and humidity values from the garage environment
+- **Switch commands** — on/off commands sent to power sockets (chargers, dehumidifiers)
+- **Automation outcomes** — results of rule evaluation forwarded from garge-api
+
+These are environmental and equipment readings. They are low-sensitivity personal data — not health data, not location, not behavioral profiling. GDPR applies because they are linked to a user account, but the risk level is low.
+
+## GDPR role: data processor (Article 28)
+
+garge-operator is a **data processor** — it handles data on behalf of the user/controller (garge-api). This means:
+- Process data only for the purpose of forwarding it to garge-api. No other use.
+- Do not retain sensor readings beyond what is needed to complete a single forwarding operation.
+- Apply appropriate security during transit.
+
+## Specific obligations
+
+### Data minimization in MQTT payloads (Article 5c)
+Extract only the fields garge-api needs. Ignore and discard unknown or extra fields from device payloads — do not pass them through blindly.
+
+```csharp
+// BAD — forwarding raw payload without filtering
+var raw = JsonSerializer.Deserialize<Dictionary<string, object>>(message);
+await apiClient.PostAsync("/sensor-data", raw);
+
+// GOOD — map to a defined DTO with only required fields
+var raw = JsonSerializer.Deserialize<RawSensorPayload>(message);
+var dto = new CreateSensorDataDto {
+    DeviceId = raw.DeviceId,
+    Value = raw.Value,
+    Timestamp = raw.Timestamp
+};
+await apiClient.PostAsync("/sensor-data", dto);
+```
+
+### No persistent storage of sensor data
+- garge-operator must not write sensor readings to disk or any persistent local store.
+- In-memory caches (dictionaries for last-known device state) are acceptable — they are transient.
+- If you add file-based logging or caching, ensure it contains no sensor readings or user data.
+
+### Logging — no payload content in logs (Article 5f)
+Log operational events, not data content. Sensor values are personal data (linked to a user) and should not appear in log output.
+
+```csharp
+// BAD — logs the actual reading
+_logger.LogInformation("Received battery reading: {Value}V for device {DeviceId}", value, deviceId);
+
+// GOOD — logs that something happened, not what
+_logger.LogInformation("Forwarded battery reading for device {DeviceId}", deviceId);
+```
+
+Connection events, errors, and automation reconciliation steps can be logged normally.
+
+### Secure data transmission (Article 32)
+- All HTTP calls to garge-api must use HTTPS. Never fall back to plain HTTP.
+- Use TLS for the MQTT broker connection where the broker supports it.
+- Credentials come from configuration (User Secrets in dev, environment variables in production) — never hardcoded.
+- Do not disable TLS certificate validation.
+
+## Checklist for new MQTT handlers or forwarding logic
+- [ ] Is only the minimum necessary data extracted from the MQTT payload?
+- [ ] Is forwarding done over HTTPS with a valid certificate?
+- [ ] Does Serilog logging avoid including sensor values or user-identifying content?
+- [ ] Is there no persistent local storage of sensor data?
+- [ ] Are credentials sourced from configuration, not hardcoded?

--- a/.claude/agents/mqtt-handler.md
+++ b/.claude/agents/mqtt-handler.md
@@ -1,0 +1,34 @@
+---
+name: mqtt-handler
+description: Add a new MQTT topic handler or device interaction to garge-operator. Use this when adding support for a new device type, a new sensor topic, or a new switch command — it will extend MqttService correctly and wire up the API call.
+---
+
+You are a specialist agent for extending MQTT device support in garge-operator, a .NET 8 Worker Service.
+
+## Architecture reminder
+
+- `MqttService.cs` owns all MQTT logic — subscriptions, message handling, publishing
+- `Worker.cs` orchestrates the polling loop and calls into `MqttService`
+- Device state is tracked in in-memory dictionaries in `MqttService`
+- All API calls use `HttpClientFactory` — never `new HttpClient()`
+
+## Your job
+
+Given a description of the new device/topic/command, you will:
+1. Add the topic subscription in the appropriate connect/subscribe method in `MqttService`
+2. Add the message handler method following the existing pattern
+3. Add or update model classes in `Models/` for the new data shape
+4. Add the HTTP call to garge-api if sensor data needs to be forwarded
+5. Update `Worker.cs` only if orchestration changes are needed
+
+## Rules to follow
+
+- MQTT logic stays in `MqttService` — do not add it to `Worker.cs`
+- Use the MQTTnet managed client APIs — do not create a raw client
+- Use structured Serilog logging: `_logger.LogInformation("Received {Topic}", topic)`
+- Use `HttpClientFactory` for all API calls
+- Handle nullable values explicitly — nullable reference types are on
+
+## Output
+
+Show all changes made, which topics are now subscribed/published, and the data flow from MQTT message to API call (or vice versa).

--- a/.claude/agents/security-review.md
+++ b/.claude/agents/security-review.md
@@ -1,0 +1,41 @@
+---
+name: security-review
+description: Security review for garge-operator. Use this agent when you want to audit the worker service for security issues — hardcoded credentials, insecure MQTT/HTTP connections, secret handling, or unsafe deserialization of device payloads.
+---
+
+You are a security reviewer for garge-operator, a .NET 8 Worker Service that connects MQTT devices to garge-api.
+
+## What to check
+
+### Credentials and secrets
+- MQTT broker credentials, API credentials, and any API keys must come from configuration (User Secrets in dev, environment variables in production). Flag any hardcoded values.
+- Check `appsettings.json` committed to the repo — it must contain no real credentials, only placeholder or dev-safe values.
+- Verify that secrets are not logged by Serilog at any log level.
+
+### Network security
+- All HTTP calls to garge-api must use HTTPS. Flag any `http://` base URLs in configuration or code.
+- TLS certificate validation must not be disabled — check for `ServerCertificateCustomValidationCallback` or `DangerousAcceptAnyServerCertificateValidator` usage.
+- MQTT broker connection should use TLS where the broker supports it. Flag plain-text MQTT if TLS is available.
+
+### MQTT payload handling
+- Incoming MQTT payloads come from IoT devices and should be treated as untrusted input.
+- Always deserialise into a typed DTO — never pass raw payloads directly to the API.
+- Validate that required fields are present and within expected ranges before forwarding (e.g., voltage values should be in a plausible range for vehicle batteries).
+- Catch and handle malformed JSON gracefully — a bad payload from one device must not crash the worker.
+
+### HttpClient usage
+- Only `HttpClientFactory` should be used for API calls. Flag any `new HttpClient()` instantiation, which bypasses connection pooling and certificate handling.
+
+### Dependency hygiene
+- Check for known vulnerable NuGet packages (`dotnet list package --vulnerable`).
+- MQTTnet, Serilog, and the .NET runtime should be on current patch versions.
+
+## Output format
+
+Report findings grouped by severity:
+- **Critical** — hardcoded credentials, disabled TLS validation, plain HTTP for data forwarding
+- **High** — unvalidated MQTT payloads, secrets in committed config files
+- **Medium** — missing payload range validation, logging of sensitive data
+- **Low** — minor hardening, outdated packages
+
+For each finding: file + method name, what the risk is, and a concrete fix.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   dev:
     if: github.ref == 'refs/heads/development'
-    uses: equinor/ops-actions/.github/workflows/docker.yml@6f3c4901194b286f11800f60fc034417e2c8480a # v9.36.0
+    uses: equinor/ops-actions/.github/workflows/docker.yml@39749d0c32762076499120f881e963687374420c # v9.37.1
     secrets:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     with:
@@ -31,7 +31,7 @@ jobs:
 
   prod:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    uses: equinor/ops-actions/.github/workflows/docker.yml@6f3c4901194b286f11800f60fc034417e2c8480a # v9.36.0
+    uses: equinor/ops-actions/.github/workflows/docker.yml@39749d0c32762076499120f881e963687374420c # v9.37.1
     secrets:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ permissions:
 jobs:
   release-please:
     name: Release Please
-    uses: equinor/ops-actions/.github/workflows/release-please.yml@6f3c4901194b286f11800f60fc034417e2c8480a # v9.36.0
+    uses: equinor/ops-actions/.github/workflows/release-please.yml@39749d0c32762076499120f881e963687374420c # v9.37.1
     with:
       release_type: simple

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# garge-operator
+
+.NET 8 Worker Service that bridges MQTT device communication with garge-api. Polls automation rules, manages MQTT device connections, and forwards sensor data to the API.
+
+## Domain Context
+
+Garge is a smart garage system for vehicles (motorcycles etc.). Two sensor types exist today:
+- **Battery sensor** — measures vehicle battery voltage (e.g., trigger charger socket when below 12.5V)
+- **Temp/humidity sensor** — measures garage environment (e.g., trigger dehumidifier socket when humidity exceeds 50%)
+
+Switches are controllable power sockets attached to devices like battery chargers or dehumidifiers. The operator receives raw sensor readings via MQTT and forwards them to garge-api, which evaluates automation rules and sends switch commands back through the operator to the MQTT broker.
+
+## Tech Stack
+
+| Concern | Library |
+|---|---|
+| Framework | .NET 8 Worker Service (IHostedService) |
+| Language | C# (nullable reference types) |
+| MQTT | MQTTnet v4 (managed client) |
+| HTTP | HttpClientFactory → garge-api |
+| Logging | Serilog |
+| Config | appsettings.json + User Secrets |
+
+## Architecture
+
+Two primary classes drive all behavior:
+
+- **`Worker.cs`** — The orchestrator. Runs the main background loop: authenticates with garge-api, polls automation rules, and reconciles device state on startup. Keep it thin — it coordinates, it does not implement.
+- **`Services/MqttService.cs`** — Handles everything MQTT: broker connection, topic subscriptions, device discovery, sensor data collection, and switch command publishing.
+
+Supporting pieces:
+```
+Models/    # Domain models: Sensor, Switch, SensorData, payload types
+Dtos/      # Types for API request/response shapes
+Services/  # Additional services registered in Program.cs
+```
+
+## Architecture Rules
+
+### Separation of Concerns
+- `Worker.cs` calls into `MqttService` — it does not contain MQTT logic itself.
+- All MQTT operations (connect, subscribe, publish, device state tracking) belong in `MqttService`.
+- Additional services go in `Services/` and are registered in `Program.cs` via DI.
+
+### API Communication
+- Always use `HttpClientFactory` for HTTP calls to garge-api. Never instantiate `HttpClient` directly.
+- API base URL and credentials come from configuration — not hardcoded.
+- Authenticate once at startup and refresh tokens when they expire. Do not re-authenticate on every request.
+
+### State Management
+- Device state and caches (last published actions, electricity price cache) live in in-memory dictionaries.
+- There is no local persistent state — garge-api and the MQTT broker are the sources of truth.
+- Keep shared state minimal and clearly owned by one class.
+
+### MQTT Patterns
+- Use the MQTTnet managed client for automatic reconnection handling.
+- Subscribe to device topics on initial connection and resubscribe after reconnect.
+- **Sensor data flow**: MQTT message → `MqttService` handler → HTTP POST to garge-api.
+- **Switch command flow**: automation rule / webhook trigger → `Worker` → `MqttService.PublishAsync` → MQTT broker → device.
+
+### Logging
+- Serilog only. Inject `ILogger<T>` via DI — never use `Console.WriteLine`.
+- Use structured logging with named placeholders: `_logger.LogError(ex, "Failed to publish to {Topic}", topic)`.
+- Log MQTT connection events, device discoveries, and automation reconciliation at Information level.
+
+## Naming Conventions
+
+| Thing | Convention | Example |
+|---|---|---|
+| Models | Singular PascalCase | `Sensor.cs`, `SwitchConfig.cs` |
+| Payload types | `<Domain>Payload.cs` | `WebhookPayload.cs`, `BatteryHealthPayload.cs` |
+| DTOs | `<Action><Domain>Dto.cs` | `CreateSensorDataDto.cs` |
+
+## What to Avoid
+- Do not access the database directly — all data goes through garge-api HTTP calls.
+- Do not put MQTT logic in `Worker.cs` — it belongs in `MqttService`.
+- Do not use `new HttpClient()` — always use `HttpClientFactory`.
+- Do not use `Console.WriteLine` — use Serilog.
+- Do not commit secrets to `appsettings.json` — use User Secrets for development and environment variables in production.
+- Do not ignore nullable reference warnings — handle nulls explicitly.

--- a/Dtos/Mqtt/SensorStatePayload.cs
+++ b/Dtos/Mqtt/SensorStatePayload.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+
+namespace garge_operator.Dtos.Mqtt
+{
+    /// <summary>
+    /// JSON payload sent by sensors that report a single numeric reading.
+    /// Expected format: { "value": 12.34 }
+    /// </summary>
+    public class SensorStatePayload
+    {
+        public JsonElement Value { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # garge-operator
+
+.NET 8 Worker Service that bridges MQTT device communication with garge-api. Receives sensor readings from the MQTT broker, forwards them to the API, and publishes switch commands back to physical devices when automation rules trigger.
+
+## How it works
+
+1. Connects to the MQTT broker and subscribes to sensor topics (battery voltage, temperature, humidity).
+2. Forwards incoming sensor data to garge-api via HTTP.
+3. Exposes a `/webhook` endpoint — garge-api calls this when an automation rule fires.
+4. Publishes the resulting switch command (on/off) back to the MQTT broker.
+
+On startup it reconciles device state: any rules that should be active are re-enforced, and expired timers are reset.
+
+## Tech stack
+
+- **.NET 8 Worker Service**
+- **MQTTnet v4** — managed MQTT client with auto-reconnection
+- **HttpClientFactory** — HTTP calls to garge-api
+- **Serilog** — structured logging
+
+## Configuration
+
+Set the following in `appsettings.json` or via environment variables:
+
+| Key | Description |
+|-----|-------------|
+| `Api:BaseUrl` | URL to garge-api |
+| `Api:Username` / `Api:Password` | Credentials for authenticating with the API |
+| `Mqtt:Host` | MQTT broker host |
+| `Mqtt:Username` / `Mqtt:Password` | MQTT broker credentials |
+
+Use [.NET User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) for local development — never commit credentials to `appsettings.json`.
+
+## Running
+
+```bash
+dotnet run
+```

--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -87,6 +87,8 @@ namespace garge_operator.Services
             }
         }
 
+        public Switch? GetSwitch(int targetId) => _switches.FirstOrDefault(s => s.Id == targetId);
+
         public async Task ConnectAsync()
         {
             // Ensure login is successful before connecting to MQTT broker
@@ -271,14 +273,14 @@ namespace garge_operator.Services
                                 {
                                     if (payload.TrimStart().StartsWith("{") || payload.TrimStart().StartsWith("["))
                                     {
-                                        var data = JsonSerializer.Deserialize<Dictionary<string, object>>(payload);
-                                        if (data != null && data.TryGetValue("value", out var value) && value != null)
+                                        var data = JsonSerializer.Deserialize<SensorStatePayload>(payload);
+                                        if (data != null && data.Value.ValueKind != JsonValueKind.Undefined)
                                         {
-                                            await SendDataToApi(entity, value.ToString());
+                                            await SendDataToApi(entity, data.Value.ToString());
                                         }
                                         else
                                         {
-                                            _logger.LogWarning($"Sensor state payload for {entity} did not contain a valid 'value' property.");
+                                            _logger.LogWarning("Sensor state payload for {Entity} did not contain a valid 'value' property.", entity);
                                         }
                                     }
                                     else
@@ -618,7 +620,7 @@ namespace garge_operator.Services
         {
             try
             {
-                _logger.LogInformation($"Preparing to send data for sensor {uniqId} to API with value: {value}");
+                _logger.LogInformation("Preparing to send data for sensor {SensorId} to API.", uniqId);
 
                 var token = await GetJwtTokenAsync();
                 var client = _httpClientFactory.CreateClient();

--- a/Worker.cs
+++ b/Worker.cs
@@ -306,14 +306,7 @@ public class Worker : BackgroundService
         return (client, rules);
     }
 
-    private Switch? GetSwitch(int targetId)
-    {
-        var switches = _mqttService
-            .GetType()
-            .GetField("_switches", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
-            .GetValue(_mqttService) as List<Switch>;
-        return switches?.FirstOrDefault(s => s.Id == targetId);
-    }
+    private Switch? GetSwitch(int targetId) => _mqttService.GetSwitch(targetId);
 
     private async Task<double?> GetSensorValueAsync(HttpClient client, string apiBaseUrl, int sensorId, CancellationToken stoppingToken)
     {


### PR DESCRIPTION
Re-applies the changes from the squash-merged and reverted development PR (#77/#78) as proper conventional commits so release-please can trigger a release.

## Changes
- `fix: replace reflection-based GetSwitch with public accessor and use typed MQTT payload DTO`
- `chore: add CLAUDE.md and agent configurations`
- `ci: update workflow action references`

**Merge without squash** to preserve the individual conventional commits.