### PR TITLE
fix: add JsonPropertyName attribute to SensorStatePayload.Value (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.3](https://github.com/sondresjolyst/garge-operator/compare/v1.4.2...v1.4.3) (2026-04-29)
+
+
+### Bug Fixes
+
+* re-apply development changes with conventional commits ([#79](https://github.com/sondresjolyst/garge-operator/issues/79)) ([5d33fba](https://github.com/sondresjolyst/garge-operator/commit/5d33fba1c102062c5406c2c2fe424fad9075df26))
+
 ## [1.4.2](https://github.com/sondresjolyst/garge-operator/compare/v1.4.1...v1.4.2) (2026-04-18)
 
 

--- a/Dtos/Mqtt/SensorStatePayload.cs
+++ b/Dtos/Mqtt/SensorStatePayload.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace garge_operator.Dtos.Mqtt
 {
@@ -8,6 +9,7 @@ namespace garge_operator.Dtos.Mqtt
     /// </summary>
     public class SensorStatePayload
     {
+        [JsonPropertyName("value")]
         public JsonElement Value { get; set; }
     }
 }


### PR DESCRIPTION
* Development (#55)

* feat: skip disabled automation rules and record last triggered timestamp (#50)

- AutomationRuleDto: add IsEnabled field
- Worker: skip rules where IsEnabled is false
- Worker: call PATCH /api/automation/{id}/triggered after successful publish

* ci: release please

* ci: release please

* chore(main): release 1.4.0 (#61)



* chore(main): release 1.4.1 (#65)



* fix: automation socket target type (#66) (#67)

* Development (#55)

* feat: skip disabled automation rules and record last triggered timestamp (#50)

- AutomationRuleDto: add IsEnabled field
- Worker: skip rules where IsEnabled is false
- Worker: call PATCH /api/automation/{id}/triggered after successful publish

* ci: release please

* ci: release please

* chore(main): release 1.4.0 (#61)



* fix(worker): accept any switch type as automation target

The TargetType check hardcoded 'Switch', causing rules whose target was created with type 'SOCKET' (post-API migration) to be silently skipped.

Older switches have TargetType='switch', newer ones have TargetType='SOCKET'. Rather than enumerating type strings, drop the check entirely and rely on GetSwitch() returning non-null as the validity gate — if the target exists in the switches list, it is actionable regardless of its type string.

* fix(worker): restore actionable-type guard using switch's own Type field

Re-add the TargetType guard that was removed in the PR fix, but check targetSwitch.Type (the live device type) instead of rule.TargetType (the potentially stale string on the rule DTO).

Only 'SOCKET' is accepted. SHRGBC and any unknown types are excluded as automation rules are only supported for socket devices.

* chore(main): release 1.4.1 (#65)



---------



* chore(main): release 1.4.2 (#68)



* deps: bump `Serilog.Sinks.Console` from 6.0.0 to 6.1.1 (#69)

---
updated-dependencies:
- dependency-name: Serilog.Sinks.Console dependency-version: 6.1.1 dependency-type: direct:production update-type: version-update:semver-minor ...




* Revert "Development"

* fix: re-apply development changes with conventional commits (#79)

* fix: replace reflection-based GetSwitch with public accessor and use typed MQTT payload DTO

* chore: add CLAUDE.md and agent configurations

* ci: update workflow action references

* chore(main): release 1.4.3 (#80)



* fix: add JsonPropertyName attribute to SensorStatePayload.Value

---------