### PR TITLE
fix: disable config reloadOnChange to prevent inotify exhaustion in k8s

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,7 +8,11 @@ using System.Text.Json;
 var builder = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration((context, config) =>
     {
-        config.AddUserSecrets<Program>();
+        config.Sources.Clear();
+        config.AddJsonFile("appsettings.json", optional: false, reloadOnChange: false);
+        config.AddJsonFile($"appsettings.{context.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: false);
+        config.AddEnvironmentVariables();
+        config.AddUserSecrets<Program>(optional: true);
     });
 
 var host = builder


### PR DESCRIPTION
## Summary
- `Host.CreateDefaultBuilder` adds `appsettings.json` with `reloadOnChange: true` by default, creating inotify file watchers on Linux
- In Kubernetes, the node-level `fs.inotify.max_user_instances` limit (default 128) is shared across all pods and gets exhausted
- Clear default config sources and re-add JSON files with `reloadOnChange: false`; env vars and user secrets preserved

## Test plan
- [ ] Deploy to Kubernetes and verify `failed to create fsnotify watcher: too many open files` error is gone
- [ ] Verify configuration still loads correctly (API URL, credentials, MQTT settings)
- [ ] Verify environment-specific appsettings override still works