### PR TITLE
deps: bump `equinor/ops-actions/.github/workflows/release-please.yml` from 9.37.1 to 9.37.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ permissions:
 jobs:
   release-please:
     name: Release Please
-    uses: equinor/ops-actions/.github/workflows/release-please.yml@39749d0c32762076499120f881e963687374420c # v9.37.1
+    uses: equinor/ops-actions/.github/workflows/release-please.yml@e925ef9959a37d43073b77efa2f73c64253fbd55 # v9.37.2
     with:
       release_type: simple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [1.5.1](https://github.com/sondresjolyst/garge-operator/compare/v1.5.0...v1.5.1) (2026-05-02)
+
+
+### Bug Fixes
+
+* skip non-timed rules in startup reconciliation when condition not met ([#89](https://github.com/sondresjolyst/garge-operator/issues/89)) ([5a93344](https://github.com/sondresjolyst/garge-operator/commit/5a93344fd111a87187be80ccf03f73d6602f6b1e))
+
+## [1.5.0](https://github.com/sondresjolyst/garge-operator/compare/v1.4.4...v1.5.0) (2026-05-02)
+
+
+### Features
+
+* automated test suite ([#86](https://github.com/sondresjolyst/garge-operator/issues/86)) ([ed51d88](https://github.com/sondresjolyst/garge-operator/commit/ed51d88cd124cb7c66d775b2955a0a33ce925874))
+
+
+### Bug Fixes
+
+* address security advisory GHSA-q83g-3j26-qh5x ([#85](https://github.com/sondresjolyst/garge-operator/issues/85)) ([da2c8b8](https://github.com/sondresjolyst/garge-operator/commit/da2c8b805f409a774fec5ebe61f3a23f6b4a8041))
+
+## [1.4.4](https://github.com/sondresjolyst/garge-operator/compare/v1.4.3...v1.4.4) (2026-04-30)
+
+
+### Bug Fixes
+
+* add JsonPropertyName attribute to SensorStatePayload.Value ([#81](https://github.com/sondresjolyst/garge-operator/issues/81)) ([2100f4c](https://github.com/sondresjolyst/garge-operator/commit/2100f4cd323bb8777efae59cad8d936493e50a74))
+* add JsonPropertyName attribute to SensorStatePayload.Value ([#81](https://github.com/sondresjolyst/garge-operator/issues/81)) ([b17319c](https://github.com/sondresjolyst/garge-operator/commit/b17319cc3767922aaf724fd72c0fbbaf64b8f1db))
+
 ## [1.4.3](https://github.com/sondresjolyst/garge-operator/compare/v1.4.2...v1.4.3) (2026-04-29)
 
 


### PR DESCRIPTION
… from 9.37.1 to 9.37.2 (#95)

* Development (#55)

* feat: skip disabled automation rules and record last triggered timestamp (#50)

- AutomationRuleDto: add IsEnabled field
- Worker: skip rules where IsEnabled is false
- Worker: call PATCH /api/automation/{id}/triggered after successful publish

* ci: release please

* ci: release please

* chore(main): release 1.4.0 (#61)



* chore(main): release 1.4.1 (#65)



* fix: automation socket target type (#66) (#67)

* Development (#55)

* feat: skip disabled automation rules and record last triggered timestamp (#50)

- AutomationRuleDto: add IsEnabled field
- Worker: skip rules where IsEnabled is false
- Worker: call PATCH /api/automation/{id}/triggered after successful publish

* ci: release please

* ci: release please

* chore(main): release 1.4.0 (#61)



* fix(worker): accept any switch type as automation target

The TargetType check hardcoded 'Switch', causing rules whose target was created with type 'SOCKET' (post-API migration) to be silently skipped.

Older switches have TargetType='switch', newer ones have TargetType='SOCKET'. Rather than enumerating type strings, drop the check entirely and rely on GetSwitch() returning non-null as the validity gate — if the target exists in the switches list, it is actionable regardless of its type string.

* fix(worker): restore actionable-type guard using switch's own Type field

Re-add the TargetType guard that was removed in the PR fix, but check targetSwitch.Type (the live device type) instead of rule.TargetType (the potentially stale string on the rule DTO).

Only 'SOCKET' is accepted. SHRGBC and any unknown types are excluded as automation rules are only supported for socket devices.

* chore(main): release 1.4.1 (#65)



---------



* chore(main): release 1.4.2 (#68)



* deps: bump `Serilog.Sinks.Console` from 6.0.0 to 6.1.1 (#69)

---
updated-dependencies:
- dependency-name: Serilog.Sinks.Console dependency-version: 6.1.1 dependency-type: direct:production update-type: version-update:semver-minor ...




* Revert "Development"

* fix: re-apply development changes with conventional commits (#79)

* fix: replace reflection-based GetSwitch with public accessor and use typed MQTT payload DTO

* chore: add CLAUDE.md and agent configurations

* ci: update workflow action references

* chore(main): release 1.4.3 (#80)



* chore(main): release 1.4.4 (#83)



* chore(main): release 1.5.0 (#88)



* chore(main): release 1.5.1 (#92)



* deps: bump equinor/ops-actions/.github/workflows/release-please.yml

Bumps [equinor/ops-actions/.github/workflows/release-please.yml](https://github.com/equinor/ops-actions) from 9.37.1 to 9.37.2.
- [Release notes](https://github.com/equinor/ops-actions/releases)
- [Changelog](https://github.com/equinor/ops-actions/blob/main/CHANGELOG.md)
- [Commits](https://github.com/equinor/ops-actions/compare/39749d0c32762076499120f881e963687374420c...e925ef9959a37d43073b77efa2f73c64253fbd55)

---
updated-dependencies:
- dependency-name: equinor/ops-actions/.github/workflows/release-please.yml dependency-version: 9.37.2 dependency-type: direct:production update-type: version-update:semver-patch ...



---------