### PR TITLE
fix: ignore pre-switch echo state from WiZ devices

### DIFF
--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -27,11 +27,23 @@ namespace garge_operator.Services
         private readonly Dictionary<string, string> _lastPublishedSwitchStates = new();
         private readonly HashSet<string> _subscribedTopics = new();
 
-        // Tracks when we last sent a command for each switch, used to rate-limit retries
-        // while waiting for the device to confirm via /state. The automation loop runs every
-        // minute and would re-send commands continuously without this guard.
+        // Tracks the last command sent per switch so the /state handler can distinguish a
+        // genuine post-switch confirmation from a WiZ pre-switch echo (the device replies with
+        // its current/pre-toggle state before the relay actually moves). Within the grace
+        // window, contradicting /state messages are ignored as echoes.
         private readonly Dictionary<string, (string Action, DateTime SentAt)> _lastCommandedAt = new();
-        private static readonly TimeSpan CommandRetryInterval = TimeSpan.FromMinutes(5);
+        internal static readonly TimeSpan CommandEchoGrace = TimeSpan.FromSeconds(30);
+
+        internal static bool IsPreSwitchEcho(
+            string incomingState,
+            (string Action, DateTime SentAt)? lastCommand,
+            DateTime now,
+            TimeSpan graceWindow)
+        {
+            if (lastCommand is not { } cmd) return false;
+            if (string.Equals(incomingState, cmd.Action, StringComparison.Ordinal)) return false;
+            return (now - cmd.SentAt) < graceWindow;
+        }
 
         // JWT token cache
         private string? _cachedToken;
@@ -296,36 +308,31 @@ namespace garge_operator.Services
 
                         if (isSwitchEntity)
                         {
-                            // Ignore state messages that contradict a command sent within the last 30 seconds.
-                            // WiZ devices echo their current (pre-switch) state immediately upon receiving a
-                            // command — before the relay physically changes. Without this guard that echo
-                            // overwrites the optimistic state set in PublishSwitchDataAsync, so the DB records
-                            // the wrong state until the device's next periodic publish (which may never come).
-                            const int CommandEchoGraceSeconds = 30;
+                            var normalizedState = payload.ToUpperInvariant();
                             bool isPreSwitchEcho;
                             lock (_stateLock)
                             {
-                                isPreSwitchEcho =
-                                    _lastCommandedAt.TryGetValue(entity, out var lastCmd) &&
-                                    !string.Equals(payload, lastCmd.Action, StringComparison.OrdinalIgnoreCase) &&
-                                    (DateTime.UtcNow - lastCmd.SentAt).TotalSeconds < CommandEchoGraceSeconds;
+                                (string, DateTime)? lastCmd = _lastCommandedAt.TryGetValue(entity, out var lc)
+                                    ? (lc.Action, lc.SentAt)
+                                    : null;
+                                isPreSwitchEcho = IsPreSwitchEcho(normalizedState, lastCmd, DateTime.UtcNow, CommandEchoGrace);
                             }
 
                             if (isPreSwitchEcho)
                             {
                                 _logger.LogInformation(
                                     "Ignoring pre-switch echo state '{State}' for {Entity} — device echoed its current state before physically switching.",
-                                    payload.ToUpperInvariant(), entity);
+                                    normalizedState, entity);
                                 break;
                             }
 
-                            await SendSwitchDataToApi(entity, "state", payload);
+                            await SendSwitchDataToApi(entity, "state", normalizedState);
                             lock (_stateLock)
                             {
-                                _lastPublishedSwitchStates[entity] = payload.ToUpperInvariant();
+                                _lastPublishedSwitchStates[entity] = normalizedState;
                                 _lastCommandedAt.Remove(entity);
                             }
-                            _logger.LogInformation("Updated local switch state for {Entity} to {State}.", entity, payload.ToUpperInvariant());
+                            _logger.LogInformation("Updated local switch state for {Entity} to {State}.", entity, normalizedState);
                         }
                         else if (isSensorEntity)
                         {
@@ -886,23 +893,24 @@ namespace garge_operator.Services
         {
             try
             {
+                var normalizedPayload = payload.ToUpperInvariant();
                 string switchNameForPublish;
                 lock (_stateLock)
                 {
                     switchNameForPublish = topic.Split('/')[2];
                     if (_lastPublishedSwitchStates.TryGetValue(switchNameForPublish, out var currentState) &&
-                        string.Equals(currentState, payload, StringComparison.OrdinalIgnoreCase))
+                        string.Equals(currentState, normalizedPayload, StringComparison.Ordinal))
                     {
-                        var sanitizedPayload = payload.Replace("\r", "").Replace("\n", "");
+                        var sanitizedPayload = normalizedPayload.Replace("\r", "").Replace("\n", "");
                         _logger.LogInformation("Skipping publish for switch {SwitchName} as the state {State} is unchanged.", switchNameForPublish, sanitizedPayload);
                         return;
                     }
 
-                    _lastPublishedSwitchStates[switchNameForPublish] = payload;
-                    _lastCommandedAt[switchNameForPublish] = (payload, DateTime.UtcNow);
+                    _lastPublishedSwitchStates[switchNameForPublish] = normalizedPayload;
+                    _lastCommandedAt[switchNameForPublish] = (normalizedPayload, DateTime.UtcNow);
                 }
 
-                var messagePayload = payload.ToUpperInvariant();
+                var messagePayload = normalizedPayload;
 
                 var message = new MqttApplicationMessageBuilder()
                     .WithTopic(topic)

--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -27,6 +27,12 @@ namespace garge_operator.Services
         private readonly Dictionary<string, string> _lastPublishedSwitchStates = new();
         private readonly HashSet<string> _subscribedTopics = new();
 
+        // Tracks when we last sent a command for each switch, used to rate-limit retries
+        // while waiting for the device to confirm via /state. The automation loop runs every
+        // minute and would re-send commands continuously without this guard.
+        private readonly Dictionary<string, (string Action, DateTime SentAt)> _lastCommandedAt = new();
+        private static readonly TimeSpan CommandRetryInterval = TimeSpan.FromMinutes(5);
+
         // JWT token cache
         private string? _cachedToken;
         private DateTime _tokenExpiry = DateTime.MinValue;
@@ -290,10 +296,34 @@ namespace garge_operator.Services
 
                         if (isSwitchEntity)
                         {
+                            // Ignore state messages that contradict a command sent within the last 30 seconds.
+                            // WiZ devices echo their current (pre-switch) state immediately upon receiving a
+                            // command — before the relay physically changes. Without this guard that echo
+                            // overwrites the optimistic state set in PublishSwitchDataAsync, so the DB records
+                            // the wrong state until the device's next periodic publish (which may never come).
+                            const int CommandEchoGraceSeconds = 30;
+                            bool isPreSwitchEcho;
+                            lock (_stateLock)
+                            {
+                                isPreSwitchEcho =
+                                    _lastCommandedAt.TryGetValue(entity, out var lastCmd) &&
+                                    !string.Equals(payload, lastCmd.Action, StringComparison.OrdinalIgnoreCase) &&
+                                    (DateTime.UtcNow - lastCmd.SentAt).TotalSeconds < CommandEchoGraceSeconds;
+                            }
+
+                            if (isPreSwitchEcho)
+                            {
+                                _logger.LogInformation(
+                                    "Ignoring pre-switch echo state '{State}' for {Entity} — device echoed its current state before physically switching.",
+                                    payload.ToUpperInvariant(), entity);
+                                break;
+                            }
+
                             await SendSwitchDataToApi(entity, "state", payload);
                             lock (_stateLock)
                             {
                                 _lastPublishedSwitchStates[entity] = payload.ToUpperInvariant();
+                                _lastCommandedAt.Remove(entity);
                             }
                             _logger.LogInformation("Updated local switch state for {Entity} to {State}.", entity, payload.ToUpperInvariant());
                         }
@@ -856,17 +886,20 @@ namespace garge_operator.Services
         {
             try
             {
+                string switchNameForPublish;
                 lock (_stateLock)
                 {
-                    var switchName = topic.Split('/')[2];
-                    if (_lastPublishedSwitchStates.TryGetValue(switchName, out var currentState) && currentState == payload)
+                    switchNameForPublish = topic.Split('/')[2];
+                    if (_lastPublishedSwitchStates.TryGetValue(switchNameForPublish, out var currentState) &&
+                        string.Equals(currentState, payload, StringComparison.OrdinalIgnoreCase))
                     {
                         var sanitizedPayload = payload.Replace("\r", "").Replace("\n", "");
-                        _logger.LogInformation("Skipping publish for switch {SwitchName} as the state {State} is unchanged.", switchName, sanitizedPayload);
+                        _logger.LogInformation("Skipping publish for switch {SwitchName} as the state {State} is unchanged.", switchNameForPublish, sanitizedPayload);
                         return;
                     }
 
-                    _lastPublishedSwitchStates[switchName] = payload;
+                    _lastPublishedSwitchStates[switchNameForPublish] = payload;
+                    _lastCommandedAt[switchNameForPublish] = (payload, DateTime.UtcNow);
                 }
 
                 var messagePayload = payload.ToUpperInvariant();

--- a/garge-operator.Tests/MqttServicePreSwitchEchoTests.cs
+++ b/garge-operator.Tests/MqttServicePreSwitchEchoTests.cs
@@ -1,0 +1,74 @@
+using garge_operator.Services;
+using Xunit;
+
+namespace garge_operator.Tests;
+
+public class MqttServicePreSwitchEchoTests
+{
+    private static readonly TimeSpan Grace = TimeSpan.FromSeconds(30);
+    private static readonly DateTime Now = new(2026, 5, 5, 1, 43, 42, DateTimeKind.Utc);
+
+    [Fact]
+    public void NoPriorCommand_NotEcho()
+    {
+        var result = MqttService.IsPreSwitchEcho("OFF", lastCommand: null, Now, Grace);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ContradictingStateWithinGrace_IsEcho()
+    {
+        var lastCmd = ("ON", Now.AddSeconds(-1));
+
+        var result = MqttService.IsPreSwitchEcho("OFF", lastCmd, Now, Grace);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContradictingStateAtGraceBoundary_NotEcho()
+    {
+        var lastCmd = ("ON", Now - Grace);
+
+        var result = MqttService.IsPreSwitchEcho("OFF", lastCmd, Now, Grace);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ContradictingStateAfterGrace_NotEcho()
+    {
+        var lastCmd = ("ON", Now.AddSeconds(-31));
+
+        var result = MqttService.IsPreSwitchEcho("OFF", lastCmd, Now, Grace);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void MatchingStateWithinGrace_NotEcho()
+    {
+        var lastCmd = ("ON", Now.AddSeconds(-5));
+
+        var result = MqttService.IsPreSwitchEcho("ON", lastCmd, Now, Grace);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void MatchingStateAfterGrace_NotEcho()
+    {
+        var lastCmd = ("ON", Now.AddSeconds(-120));
+
+        var result = MqttService.IsPreSwitchEcho("ON", lastCmd, Now, Grace);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GraceConstantIsThirtySeconds()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), MqttService.CommandEchoGrace);
+    }
+}


### PR DESCRIPTION
## Problem

Switch state in the DB was stuck on **OFF** for ~20 hours after the charger was physically turned on.

Voltage data confirmed the device switched on at ~01:43 UTC (03:43 CEST) on May 5, yet the first ON record in switch_data did not appear until midnight May 6.

---

## Root Cause (confirmed via Grafana Loki logs)

WiZ smart sockets have a specific behavior: **when they receive an ON or OFF command, they immediately echo back their current (pre-switch) state before the relay physically changes.**

The exact sequence from the logs:

| Timestamp (UTC) | Event |
|---|---|
| 01:43:05 | Voltage sensor publishes 11.599V (just below 11.6V threshold) |
| 01:43:41 | Automation Rule 7 fires: condition met, starting 48h timer, turning ON |
| 01:43:41 | Operator publishes ON to garge/devices/wiz_SOCKET_cc408572e2f0/set |
| 01:43:42 | Device echoes back its **current state: OFF** on .../wiz_SOCKET_cc408572e2f0/state |
| 01:43:47 | API responds 201 -> DB records OFF -> _lastPublishedSwitchStates = OFF |
| 01:43:42+ | No further /state messages from this device for the rest of the day |
| 01:44+    | Automation skips republishing because _lastPublishedActions[8] = "on" (set at 01:43:41) |

The device physically switched ON (voltage rose from 11.6V to 13.0V over the next hours), but because:
1. The OFF echo overwrote `_lastPublishedSwitchStates`
2. The device never sent a follow-up `/state ON` message
3. The automation timer-rule dedup blocked any retry via `_lastPublishedActions`

...the DB stayed on OFF indefinitely.

## How to verify the theory

Check the logs around **2026-05-05 01:43 UTC** in Grafana Loki:
- Look for `Published Switch data to topic 'garge/devices/wiz_SOCKET_cc408572e2f0/set': ON` at 01:43:41
- Look for `Updated local switch state for wiz_SOCKET_cc408572e2f0 to OFF` at 01:43:47
- Confirm there are **no further** state messages for `wiz_SOCKET_cc408572e2f0` until midnight
- Confirm voltage sensor 13 was rising from 01:43 onward (values ~13.x V)

---

## Fix

In `HandleReceivedMessage` (state case), before writing a device state to the DB:
- Check if the incoming state **contradicts** a command sent within the last **30 seconds**
- If so, treat it as a pre-switch echo and ignore it (logged at INFO for observability)
- Once the device confirms the commanded state (or after 30s), process normally and clear the pending command

In `PublishSwitchDataAsync`:
- Record `_lastCommandedAt[switchName] = (payload, DateTime.UtcNow)` when a command is sent
- Also fixed: dedup check now uses `OrdinalIgnoreCase` instead of `==` (was case-sensitive)

The 30-second grace window is long enough for any slow device to physically switch, but short enough that a genuine manual OFF within the same minute is still processed after the window expires.

---

## What is NOT changed

- The `_lastPublishedActions` timer-rule dedup in `Worker.cs` is unchanged
- The retained-message filter is unchanged
- No change to startup reconciliation logic