### PR TITLE
feat(signalr): receive switch events from garge-api hub

### DIFF
--- a/Models/SwitchEvent.cs
+++ b/Models/SwitchEvent.cs
@@ -1,4 +1,6 @@
-﻿public class WebhookPayload
+// Wire-format DTO for switch state events received from garge-api's
+// SignalR DeviceHub. Matches SwitchEventDto on the API side.
+public class SwitchEvent
 {
     public int Id { get; set; }
     public int SwitchId { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -1,11 +1,7 @@
-using Microsoft.AspNetCore.Builder;
 using garge_operator.Services;
-using Microsoft.AspNetCore.Hosting;
 using Serilog;
-using Microsoft.AspNetCore.Http;
-using System.Text.Json;
 
-var builder = Host.CreateDefaultBuilder(args)
+var host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration((context, config) =>
     {
         config.Sources.Clear();
@@ -13,9 +9,7 @@ var builder = Host.CreateDefaultBuilder(args)
         config.AddJsonFile($"appsettings.{context.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: false);
         config.AddEnvironmentVariables();
         config.AddUserSecrets<Program>(optional: true);
-    });
-
-var host = builder
+    })
     .UseSerilog((context, services, configuration) =>
     {
         configuration
@@ -27,56 +21,8 @@ var host = builder
     {
         services.AddSingleton<IMqttService, MqttService>();
         services.AddHostedService<Worker>();
+        services.AddHostedService<OperatorHubClient>();
         services.AddHttpClient();
-    })
-    .ConfigureWebHostDefaults(webBuilder =>
-    {
-        webBuilder.Configure(app =>
-        {
-            app.UseRouting();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapPost("/webhook", async context =>
-                {
-                    if (context.Request.ContentLength > 65536)
-                    {
-                        context.Response.StatusCode = StatusCodes.Status413RequestEntityTooLarge;
-                        await context.Response.WriteAsync("Payload too large.");
-                        return;
-                    }
-
-                    var config = context.RequestServices.GetRequiredService<IConfiguration>();
-                    var webhookSecret = config["Webhook:Secret"];
-                    if (!string.IsNullOrEmpty(webhookSecret))
-                    {
-                        var providedSecret = context.Request.Headers["X-Webhook-Secret"].FirstOrDefault();
-                        if (providedSecret != webhookSecret)
-                        {
-                            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                            await context.Response.WriteAsync("Unauthorized.");
-                            return;
-                        }
-                    }
-
-                    var mqttService = context.RequestServices.GetRequiredService<IMqttService>();
-                    var payload = await JsonSerializer.DeserializeAsync<WebhookPayload>(context.Request.Body);
-
-                    if (payload == null)
-                    {
-                        context.Response.StatusCode = StatusCodes.Status400BadRequest;
-                        await context.Response.WriteAsync("Payload is null.");
-                        return;
-                    }
-
-                    await mqttService.HandleWebhookDataAsync(payload);
-
-                    context.Response.StatusCode = StatusCodes.Status200OK;
-                    await context.Response.WriteAsync("Webhook data processed.");
-                });
-            });
-
-        });
     })
     .Build();
 

--- a/Services/IMqttService.cs
+++ b/Services/IMqttService.cs
@@ -6,6 +6,6 @@ public interface IMqttService
     Task ConnectAsync();
     Switch? GetSwitch(int targetId);
     Task<string> GetJwtTokenAsync();
-    Task HandleWebhookDataAsync(WebhookPayload payload);
+    Task HandleSwitchEventAsync(SwitchEvent evt);
     Task PublishSwitchDataAsync(string topic, string payload);
 }

--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -925,26 +925,26 @@ namespace garge_operator.Services
             }
         }
 
-        public async Task HandleWebhookDataAsync(WebhookPayload payload)
+        public async Task HandleSwitchEventAsync(SwitchEvent evt)
         {
             try
             {
-                _logger.LogDebug("Received webhook data for switch: {SwitchName}", payload.Switch?.Name);
+                _logger.LogDebug("Received switch event for switch: {SwitchName}", evt.Switch?.Name);
 
-                if (payload.Switch == null)
+                if (evt.Switch == null)
                 {
-                    _logger.LogWarning("Webhook payload does not contain a valid switch.");
+                    _logger.LogWarning("Switch event payload does not contain a valid switch.");
                     return;
                 }
 
-                var switchName = payload.Switch.Name;
+                var switchName = evt.Switch.Name;
                 if (!IsValidDeviceId(switchName))
                 {
-                    _logger.LogWarning("Webhook payload contains invalid switch name: {Name}", switchName);
+                    _logger.LogWarning("Switch event payload contains invalid switch name: {Name}", switchName);
                     return;
                 }
 
-                var state = payload.Value.ToUpperInvariant();
+                var state = evt.Value.ToUpperInvariant();
 
                 bool knownSwitch;
                 lock (_listsLock)
@@ -968,7 +968,7 @@ namespace garge_operator.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error handling webhook data.");
+                _logger.LogError(ex, "Error handling switch event.");
             }
         }
     }

--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -125,9 +125,6 @@ namespace garge_operator.Services
                 return;
             }
 
-            // Register this service as a subscriber
-            await RegisterAsSubscriberAsync();
-
             // Get all sensors from the API
             _sensors = await GetAllSensorsAsync(token);
 
@@ -925,50 +922,6 @@ namespace garge_operator.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error publishing Switch data to topic {Topic}.", topic);
-            }
-        }
-
-        public async Task RegisterAsSubscriberAsync()
-        {
-            try
-            {
-                var token = await GetJwtTokenAsync();
-                var client = _httpClientFactory.CreateClient();
-                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-
-                // Define the webhook URL for this application
-                var webhookUrl = _configuration["Webhook:Url"];
-                if (string.IsNullOrWhiteSpace(webhookUrl))
-                {
-                    _logger.LogError("Webhook URL is not configured.");
-                    return;
-                }
-
-                // Create the payload for the subscription, including webhook secret for garge-api
-                // (garge-api may ignore WebhookSecret if it does not yet support it — backwards-compatible)
-                var payload = new
-                {
-                    WebhookUrl = webhookUrl,
-                    WebhookSecret = _configuration["Webhook:Secret"]
-                };
-
-                // Send the POST request to the API's subscription endpoint
-                var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-                var response = await client.PostAsync($"{_apiBaseUrl}/api/webhook", content);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    _logger.LogInformation("Successfully registered as a subscriber.");
-                }
-                else
-                {
-                    var responseContent = await response.Content.ReadAsStringAsync();
-                    _logger.LogError("Failed to register as a subscriber. Status code: {StatusCode}, Reason: {ReasonPhrase}, Response: {ResponseContent}", response.StatusCode, response.ReasonPhrase, responseContent);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error registering as a subscriber.");
             }
         }
 

--- a/Services/OperatorHubClient.cs
+++ b/Services/OperatorHubClient.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Hosting;
+
+namespace garge_operator.Services
+{
+    public class OperatorHubClient : BackgroundService
+    {
+        private const string SwitchEventName = "switch";
+
+        private readonly IConfiguration _configuration;
+        private readonly IMqttService _mqttService;
+        private readonly ILogger<OperatorHubClient> _logger;
+        private HubConnection? _connection;
+
+        public OperatorHubClient(
+            IConfiguration configuration,
+            IMqttService mqttService,
+            ILogger<OperatorHubClient> logger)
+        {
+            _configuration = configuration;
+            _mqttService = mqttService;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var apiBase = _configuration["Api:BaseUrl"]
+                          ?? throw new InvalidOperationException("Api:BaseUrl not configured");
+            var hubUrl = $"{apiBase.TrimEnd('/')}/hubs/devices";
+
+            _connection = new HubConnectionBuilder()
+                .WithUrl(hubUrl, opts =>
+                {
+                    opts.AccessTokenProvider = async () => await _mqttService.GetJwtTokenAsync();
+                })
+                .WithAutomaticReconnect()
+                .Build();
+
+            _connection.On<WebhookPayload>(SwitchEventName, async payload =>
+            {
+                try
+                {
+                    await _mqttService.HandleWebhookDataAsync(payload);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "OperatorHubClient: failed to handle switch event");
+                }
+            });
+
+            _connection.Reconnecting += error =>
+            {
+                _logger.LogWarning(error, "OperatorHubClient: reconnecting");
+                return Task.CompletedTask;
+            };
+            _connection.Reconnected += connectionId =>
+            {
+                _logger.LogInformation("OperatorHubClient: reconnected ({ConnectionId})", connectionId);
+                return Task.CompletedTask;
+            };
+            _connection.Closed += error =>
+            {
+                _logger.LogWarning(error, "OperatorHubClient: connection closed");
+                return Task.CompletedTask;
+            };
+
+            // Retry start until success or shutdown.
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await _connection.StartAsync(stoppingToken);
+                    _logger.LogInformation("OperatorHubClient: connected to {HubUrl}", hubUrl);
+                    break;
+                }
+                catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning(ex, "OperatorHubClient: initial connect failed, retrying in 5s");
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+            }
+
+            try
+            {
+                await Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        public override async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_connection != null)
+            {
+                await _connection.DisposeAsync();
+            }
+            await base.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/Services/OperatorHubClient.cs
+++ b/Services/OperatorHubClient.cs
@@ -3,14 +3,25 @@ using Microsoft.Extensions.Hosting;
 
 namespace garge_operator.Services
 {
+    /// <summary>
+    /// Maintains a SignalR connection to garge-api's DeviceHub.
+    /// Supervision strategy:
+    ///   - WithAutomaticReconnect for short hiccups (~30s, 4 attempts).
+    ///   - On Closed (auto-reconnect exhausted) we schedule a fresh
+    ///     StartAsync with a longer back-off so a multi-minute API outage
+    ///     still recovers without restarting the operator process.
+    /// </summary>
     public class OperatorHubClient : BackgroundService
     {
         private const string SwitchEventName = "switch";
+        private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan ClosedRestartDelay = TimeSpan.FromSeconds(60);
 
         private readonly IConfiguration _configuration;
         private readonly IMqttService _mqttService;
         private readonly ILogger<OperatorHubClient> _logger;
         private HubConnection? _connection;
+        private CancellationToken _stoppingToken;
 
         public OperatorHubClient(
             IConfiguration configuration,
@@ -24,6 +35,8 @@ namespace garge_operator.Services
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            _stoppingToken = stoppingToken;
+
             var apiBase = _configuration["Api:BaseUrl"]
                           ?? throw new InvalidOperationException("Api:BaseUrl not configured");
             var hubUrl = $"{apiBase.TrimEnd('/')}/hubs/devices";
@@ -36,11 +49,11 @@ namespace garge_operator.Services
                 .WithAutomaticReconnect()
                 .Build();
 
-            _connection.On<WebhookPayload>(SwitchEventName, async payload =>
+            _connection.On<SwitchEvent>(SwitchEventName, async evt =>
             {
                 try
                 {
-                    await _mqttService.HandleWebhookDataAsync(payload);
+                    await _mqttService.HandleSwitchEventAsync(evt);
                 }
                 catch (Exception ex)
                 {
@@ -58,27 +71,21 @@ namespace garge_operator.Services
                 _logger.LogInformation("OperatorHubClient: reconnected ({ConnectionId})", connectionId);
                 return Task.CompletedTask;
             };
-            _connection.Closed += error =>
+            _connection.Closed += async error =>
             {
-                _logger.LogWarning(error, "OperatorHubClient: connection closed");
-                return Task.CompletedTask;
-            };
-
-            // Retry start until success or shutdown.
-            while (!stoppingToken.IsCancellationRequested)
-            {
+                if (_stoppingToken.IsCancellationRequested) return;
+                _logger.LogWarning(error,
+                    "OperatorHubClient: connection closed past auto-reconnect, restarting in {Delay}",
+                    ClosedRestartDelay);
                 try
                 {
-                    await _connection.StartAsync(stoppingToken);
-                    _logger.LogInformation("OperatorHubClient: connected to {HubUrl}", hubUrl);
-                    break;
+                    await Task.Delay(ClosedRestartDelay, _stoppingToken);
+                    await StartWithRetriesAsync(hubUrl);
                 }
-                catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
-                {
-                    _logger.LogWarning(ex, "OperatorHubClient: initial connect failed, retrying in 5s");
-                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
-                }
-            }
+                catch (OperationCanceledException) { }
+            };
+
+            await StartWithRetriesAsync(hubUrl);
 
             try
             {
@@ -86,6 +93,26 @@ namespace garge_operator.Services
             }
             catch (OperationCanceledException)
             {
+            }
+        }
+
+        private async Task StartWithRetriesAsync(string hubUrl)
+        {
+            while (!_stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    if (_connection!.State == HubConnectionState.Connected) return;
+                    await _connection!.StartAsync(_stoppingToken);
+                    _logger.LogInformation("OperatorHubClient: connected to {HubUrl}", hubUrl);
+                    return;
+                }
+                catch (Exception ex) when (!_stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning(ex, "OperatorHubClient: connect failed, retrying in {Delay}",
+                        InitialRetryDelay);
+                    await Task.Delay(InitialRetryDelay, _stoppingToken);
+                }
             }
         }
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,9 +8,6 @@
   "Api": {
     "BaseUrl": "https://localhost:5277"
   },
-  "Webhook": {
-    "Url": "https://localhost:5000/webhook"
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/garge-operator.csproj
+++ b/garge-operator.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.3.7.1207" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />


### PR DESCRIPTION
## Summary

- Operator now receives switch state changes from garge-api over SignalR (`/hubs/devices`) instead of the legacy inbound HTTP webhook.
- Same MQTT publish path (`HandleWebhookDataAsync` / `WebhookPayload` shape unchanged), same JWT login, no MQTT topic or broker changes.
- `/webhook` endpoint and self-registration removed. Operator is now a pure worker host (no listening port).

## OperatorHubClient

- Hosted service; builds a `HubConnection` with `WithAutomaticReconnect()`.
- `AccessTokenProvider` reuses `MqttService.GetJwtTokenAsync()` — token refresh on reconnect works for free.
- On `switch` event, forwards `WebhookPayload` to `MqttService.HandleWebhookDataAsync` (existing logic, unchanged).
- Initial connect retries every 5 s until success or shutdown.
- Logs reconnect/closed events for observability.

## Removed

- `Program.cs` `ConfigureWebHostDefaults` block and `POST /webhook` endpoint. Operator no longer listens on a port.
- `MqttService.RegisterAsSubscriberAsync` and the call to it in `ConnectAsync`.
- `Webhook:Url` config in `appsettings.json` (unused after removal).

## Dependency

- New API role `DeviceBridge` (added in garge-api PR). Operator's API user account needs this role assigned per environment, same flow as existing `MqttAdmin` assignment.

## Test plan

- [x] `dotnet test garge-operator.Tests` — 46 pass.
- [x] Build clean.
- [ ] Deploy alongside garge-api change. Confirm operator logs `OperatorHubClient: connected`.
- [ ] Toggle switch from app → operator publishes one MQTT `/set` (no longer dual-fire).
- [ ] Restart operator → `WithAutomaticReconnect()` re-establishes within ~5 s. Verify next switch toggle is received.

## Related

- garge-api: feat/signalr-device-events (Hub + dispatcher + sensor trigger + webhook removal)
- garge-app: feat/signalr-device-events (live dashboard updates)
