### PR TITLE
docs: professionalize code comments and XML docs

### DIFF
--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -27,9 +27,9 @@ namespace garge_operator.Services
         private readonly HashSet<string> _subscribedTopics = new();
 
         // Tracks the last command sent per switch so the /state handler can distinguish a
-        // genuine post-switch confirmation from a WiZ pre-switch echo (the device replies with
-        // its current/pre-toggle state before the relay actually moves). Within the grace
-        // window, contradicting /state messages are ignored as echoes.
+        // genuine post-switch confirmation from a WiZ pre-switch echo. A WiZ device reports its
+        // current pre-toggle state before the relay physically moves. Within the grace window,
+        // contradicting /state messages are treated as echoes and ignored.
         private readonly Dictionary<string, (string Action, DateTime SentAt)> _lastCommandedAt = new();
         internal static readonly TimeSpan CommandEchoGrace = TimeSpan.FromSeconds(30);
 
@@ -59,7 +59,7 @@ namespace garge_operator.Services
             _sensors = new List<Sensor>();
             _switches = new List<Switch>();
 
-            // Safely read broker & port
+            // Read and validate the broker and port.
             var broker = configuration["Mqtt:Broker"];
             if (string.IsNullOrWhiteSpace(broker))
                 throw new ArgumentException("Mqtt:Broker not set in configuration.");
@@ -68,13 +68,13 @@ namespace garge_operator.Services
             if (!int.TryParse(portString, out var port))
                 throw new ArgumentException("Mqtt:Port is invalid or not set in configuration.");
 
-            // Safely read API BaseUrl
+            // Read and validate the API base URL.
             var baseUrl = configuration["Api:BaseUrl"];
             if (string.IsNullOrWhiteSpace(baseUrl))
                 throw new ArgumentException("Api:BaseUrl not set in configuration.");
             _apiBaseUrl = baseUrl;
 
-            // Safely read username & password
+            // Read and validate the username and password.
             var username = configuration["Mqtt:Username"];
             var password = configuration["Mqtt:Password"];
             if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))

--- a/Services/OperatorHubClient.cs
+++ b/Services/OperatorHubClient.cs
@@ -6,9 +6,9 @@ namespace garge_operator.Services
     /// <summary>
     /// Maintains a SignalR connection to garge-api's DeviceHub.
     /// Supervision strategy:
-    ///   - WithAutomaticReconnect for short hiccups (~30s, 4 attempts).
-    ///   - On Closed (auto-reconnect exhausted) we schedule a fresh
-    ///     StartAsync with a longer back-off so a multi-minute API outage
+    ///   - Automatic reconnect handles short interruptions (about 30 seconds, 4 attempts).
+    ///   - When the connection closes after automatic reconnect is exhausted, a fresh
+    ///     StartAsync is scheduled with a longer back-off so a multi-minute API outage
     ///     still recovers without restarting the operator process.
     /// </summary>
     public class OperatorHubClient : BackgroundService

--- a/Worker.cs
+++ b/Worker.cs
@@ -9,10 +9,10 @@ public class Worker : BackgroundService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IConfiguration _configuration;
 
-    // Cache last published action per switchId
+    // Caches the last published action per switch, keyed by switch ID.
     private readonly Dictionary<int, string> _lastPublishedActions = new();
 
-    // Cache current electricity price per area (keyed by area, valid for current delivery hour)
+    // Caches the electricity price per area. Each entry is valid until the end of its delivery hour.
     private readonly Dictionary<string, (double Value, DateTime ValidUntil)> _priceCache = new();
 
     public Worker(
@@ -31,7 +31,7 @@ public class Worker : BackgroundService
     {
         await _mqttService.ConnectAsync();
 
-        // Reconcile rule state on startup before entering the poll loop
+        // Reconcile rule state before entering the poll loop.
         try
         {
             await ReconcileOnStartupAsync(stoppingToken);
@@ -65,8 +65,8 @@ public class Worker : BackgroundService
     }
 
     /// <summary>
-    /// On startup: immediately resolve any expired timers, re-enforce active timers,
-    /// and set correct state for non-timed rules — handles the operator-was-down case.
+    /// Reconciles rule state at startup: resolves expired timers, re-enforces active timers,
+    /// and sets the correct state for non-timed rules. Recovers state after operator downtime.
     /// </summary>
     internal async Task ReconcileOnStartupAsync(CancellationToken stoppingToken)
     {
@@ -100,14 +100,14 @@ public class Worker : BackgroundService
                     var elapsed = DateTime.UtcNow - rule.TimerActivatedAt.Value.ToUniversalTime();
                     if (elapsed >= TimeSpan.FromHours(rule.TimerDurationHours.Value))
                     {
-                        // Timer expired while operator was down — turn OFF and clear
+                        // Timer expired during operator downtime: turn the switch off and clear the timer.
                         _logger.LogInformation("Startup: timer expired for rule {RuleId}, turning OFF and clearing.", rule.Id);
                         await _mqttService.PublishSwitchDataAsync(topic, "off");
                         await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{rule.Id}/timer-clear", stoppingToken);
                     }
                     else
                     {
-                        // Timer still active — re-enforce state, gated by price condition if set
+                        // Timer still active: re-enforce state, gated by the price condition when set.
                         bool priceOk = true;
                         if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
                             rule.ElectricityPriceThreshold.HasValue &&
@@ -124,11 +124,11 @@ public class Worker : BackgroundService
                         _lastPublishedActions[rule.TargetId] = startupDesired;
                     }
                 }
-                // If TimerActivatedAt is null the rule is idle — no action needed on startup
+                // A null TimerActivatedAt means the rule is idle and requires no startup action.
             }
             else
             {
-                // Non-timed rule: evaluate condition and enforce correct state
+                // Non-timed rule: evaluate the condition and enforce the correct state.
                 var sensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
                 if (sensorValue == null) continue;
 
@@ -218,7 +218,7 @@ public class Worker : BackgroundService
                     }
                     else
                     {
-                        // Timer still running — gate socket by price condition (sensor is trigger-only)
+                        // Timer still running: gate the socket on the price condition. The sensor only acts as a trigger.
                         bool priceOk = true;
                         if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
                             rule.ElectricityPriceThreshold.HasValue &&
@@ -241,7 +241,7 @@ public class Worker : BackgroundService
                     continue;
                 }
 
-                // Timer is idle — check trigger condition
+                // Timer idle: check the trigger condition.
                 var sensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
                 if (sensorValue == null) continue;
 

--- a/garge-operator.Tests/WorkerPollTests.cs
+++ b/garge-operator.Tests/WorkerPollTests.cs
@@ -103,11 +103,11 @@ public class WorkerPollTests : WorkerTestBase
         SetupPrice("NO1", price: 0.3);
         var worker = CreateWorker();
 
-        // First call — records "on" internally
+        // First call records the "on" state internally.
         await worker.PollAutomationsAsync(CancellationToken.None);
         MockMqtt.Invocations.Clear();
 
-        // Second call — no price change, should not re-publish
+        // Second call: with no price change, the state must not be republished.
         await worker.PollAutomationsAsync(CancellationToken.None);
 
         MockMqtt.Verify(m => m.PublishSwitchDataAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -232,8 +232,8 @@ public class WorkerPollTests : WorkerTestBase
         SetupRules(rule);
         MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
         MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
-        SetupSensor(5, value: 15); // sensor condition NOT met
-        SetupPrice("NO1", price: 0.3); // price condition met
+        SetupSensor(5, value: 15); // Sensor condition is not met.
+        SetupPrice("NO1", price: 0.3); // Price condition is met.
         HttpHandler.OnPatch($"{ApiBase}/api/automation/1/triggered");
         var worker = CreateWorker();
 

--- a/garge-operator.Tests/WorkerReconcileTests.cs
+++ b/garge-operator.Tests/WorkerReconcileTests.cs
@@ -84,7 +84,7 @@ public class WorkerReconcileTests : WorkerTestBase
         var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20, action: "on");
         SetupRules(rule);
         MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
-        SetupSensor(5, value: 15); // condition not met → leave switch alone
+        SetupSensor(5, value: 15); // Condition not met: the switch is left unchanged.
         var worker = CreateWorker();
 
         await worker.ReconcileOnStartupAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary

Professionalizes code-comment and XML-doc tone across the operator, matching the cleanup done in garge-api and garge-app. Rewords chat-style comments into clear, declarative prose in `Worker`, `MqttService`, `OperatorHubClient` and two test files — removing first-person and informal asides while preserving the rationale (WiZ pre-switch echo handling, startup reconciliation, SignalR supervision and back-off).

**Comments only** — no code, MQTT topic strings, log templates, configuration keys or test assertions changed.

## Tests
No behavior change. Builds with 0 warnings; 58 tests pass.
