### PR TITLE
ci: use reusable Dependabot title workflow from garge

### DIFF
--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -9,24 +9,4 @@ permissions: {}
 jobs:
   rewrite:
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add backticks around package name
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TITLE: ${{ github.event.pull_request.title }}
-          NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          if [[ "$TITLE" == *'`'* ]]; then
-            echo "Already formatted, skipping"
-            exit 0
-          fi
-          new_title=$(printf '%s' "$TITLE" | sed -E 's/^(deps: bump )([^ ]+)( from .+)$/\1`\2`\3/')
-          if [[ "$new_title" == "$TITLE" ]]; then
-            echo "Title pattern did not match, skipping"
-            exit 0
-          fi
-          gh pr edit "$NUMBER" --title "$new_title" --repo "$REPO"
+    uses: sondresjolyst/garge/.github/workflows/dependabot-title.yml@main

--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -9,4 +9,6 @@ permissions: {}
 jobs:
   rewrite:
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
     uses: sondresjolyst/garge/.github/workflows/dependabot-title.yml@main


### PR DESCRIPTION
ci: replace the inline Dependabot title formatter with a thin caller that reuses sondresjolyst/garge/.github/workflows/dependabot-title.yml@main. Also fixes the verb-case bug: the previous regex only matched lowercase 'bump' and skipped Dependabot's capital 'Bump'. Depends on sondresjolyst/garge#103.