### PR TITLE
refactor: IOptions config, DelegatingHandler auth, idempotent timer-start

### DIFF
--- a/Models/ApiOptions.cs
+++ b/Models/ApiOptions.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_operator.Models
+{
+    /// <summary>
+    /// Strongly-typed binding for the <c>Api</c> configuration section. The keys mirror the
+    /// historical stringly-typed reads (<c>Api:BaseUrl</c>, <c>Api:Email</c>, <c>Api:Password</c>)
+    /// so existing appsettings and environment variables continue to bind unchanged.
+    /// </summary>
+    public class ApiOptions
+    {
+        public const string SectionName = "Api";
+
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Api:BaseUrl not set in configuration.")]
+        public string BaseUrl { get; set; } = string.Empty;
+
+        public string? Email { get; set; }
+
+        public string? Password { get; set; }
+    }
+}

--- a/Models/MqttOptions.cs
+++ b/Models/MqttOptions.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace garge_operator.Models
+{
+    /// <summary>
+    /// Strongly-typed binding for the <c>Mqtt</c> configuration section. The keys mirror the
+    /// historical stringly-typed reads (<c>Mqtt:Broker</c>, <c>Mqtt:Port</c>, etc.) so existing
+    /// appsettings and environment variables continue to bind unchanged. Validation that was
+    /// previously performed by hand in the MqttService constructor now lives in DataAnnotations
+    /// and is enforced at startup via ValidateOnStart.
+    /// </summary>
+    public class MqttOptions
+    {
+        public const string SectionName = "Mqtt";
+
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Mqtt:Broker not set in configuration.")]
+        public string Broker { get; set; } = string.Empty;
+
+        [Range(1, 65535, ErrorMessage = "Mqtt:Port is invalid or not set in configuration.")]
+        public int Port { get; set; }
+
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Mqtt:Username or Mqtt:Password not set in configuration.")]
+        public string Username { get; set; } = string.Empty;
+
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Mqtt:Username or Mqtt:Password not set in configuration.")]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,4 @@
+using garge_operator.Models;
 using garge_operator.Services;
 using Serilog;
 
@@ -27,6 +28,30 @@ var host = Host.CreateDefaultBuilder(args)
         {
             options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
         });
+
+        // Bind strongly-typed configuration. DataAnnotations replace the former hand-rolled
+        // constructor validation; ValidateOnStart surfaces misconfiguration at startup so the
+        // pod fails fast instead of throwing lazily on first use. The section names and keys are
+        // unchanged (Mqtt:Broker, Mqtt:Port, Api:BaseUrl, ...) so existing appsettings and
+        // environment variables continue to bind.
+        services.AddOptions<MqttOptions>()
+            .Bind(context.Configuration.GetSection(MqttOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddOptions<ApiOptions>()
+            .Bind(context.Configuration.GetSection(ApiOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        // Token provider owns JWT fetch/caching and uses an unauthenticated login client.
+        services.AddSingleton<ITokenProvider, JwtTokenProvider>();
+        services.AddTransient<BearerTokenHandler>();
+
+        // Authenticated garge-api client: BearerTokenHandler attaches the JWT automatically.
+        services.AddHttpClient(GargeApiClient.Authorized)
+            .AddHttpMessageHandler<BearerTokenHandler>();
+        // Unauthenticated client used only for the login call (no bearer handler, no recursion).
+        services.AddHttpClient(JwtTokenProvider.LoginClientName);
 
         services.AddSingleton<IMqttService, MqttService>();
         services.AddHostedService<Worker>();

--- a/Services/BearerTokenHandler.cs
+++ b/Services/BearerTokenHandler.cs
@@ -1,0 +1,29 @@
+using System.Net.Http.Headers;
+
+namespace garge_operator.Services
+{
+    /// <summary>
+    /// Attaches the JWT bearer token to every outgoing request on the authenticated garge-api
+    /// HttpClient. Replaces the per-call-site "fetch token + set Authorization header" boilerplate
+    /// with the idiomatic <see cref="DelegatingHandler"/> pattern. The token is sourced from
+    /// <see cref="ITokenProvider"/>, which caches it and fetches over an unauthenticated client,
+    /// so attaching a token here never recurses back through this handler.
+    /// </summary>
+    public class BearerTokenHandler : DelegatingHandler
+    {
+        private readonly ITokenProvider _tokenProvider;
+
+        public BearerTokenHandler(ITokenProvider tokenProvider)
+        {
+            _tokenProvider = tokenProvider;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var token = await _tokenProvider.GetJwtTokenAsync(cancellationToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/Services/GargeApiClient.cs
+++ b/Services/GargeApiClient.cs
@@ -1,0 +1,14 @@
+namespace garge_operator.Services
+{
+    /// <summary>
+    /// Shared identifiers for the named HttpClients registered in <c>Program.cs</c>.
+    /// </summary>
+    public static class GargeApiClient
+    {
+        /// <summary>
+        /// The authenticated garge-api client. Requests on this client carry the JWT bearer
+        /// automatically via <see cref="BearerTokenHandler"/>.
+        /// </summary>
+        public const string Authorized = "GargeApi";
+    }
+}

--- a/Services/HttpJson.cs
+++ b/Services/HttpJson.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using System.Text.Json;
+
+namespace garge_operator.Services
+{
+    /// <summary>
+    /// Centralizes the repeated "serialize body to JSON → POST as application/json" pattern.
+    /// Callers retain control over success/error branching and logging so existing behavior is
+    /// preserved; this helper only owns the serialization + StringContent + PostAsync steps and
+    /// reuses a single shared <see cref="JsonSerializerOptions"/> instance.
+    /// </summary>
+    public static class HttpJson
+    {
+        // Reused across all serialization calls to avoid per-call allocation. Matches the
+        // previous default JsonSerializer.Serialize behavior (no custom naming policy).
+        internal static readonly JsonSerializerOptions JsonOptions = new();
+
+        public static Task<HttpResponseMessage> PostJsonAsync<T>(
+            HttpClient client, string url, T body, CancellationToken cancellationToken = default)
+        {
+            var json = JsonSerializer.Serialize(body, JsonOptions);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            return client.PostAsync(url, content, cancellationToken);
+        }
+    }
+}

--- a/Services/IMqttService.cs
+++ b/Services/IMqttService.cs
@@ -3,7 +3,7 @@ namespace garge_operator.Services;
 public interface IMqttService
 {
     IReadOnlyDictionary<string, string> LastPublishedSwitchStates { get; }
-    Task ConnectAsync();
+    Task ConnectAsync(CancellationToken cancellationToken = default);
     Switch? GetSwitch(int targetId);
     Task<string> GetJwtTokenAsync();
     Task HandleSwitchEventAsync(SwitchEvent evt);

--- a/Services/ITokenProvider.cs
+++ b/Services/ITokenProvider.cs
@@ -1,0 +1,13 @@
+namespace garge_operator.Services
+{
+    /// <summary>
+    /// Supplies (and caches) the JWT bearer token used to authenticate against garge-api.
+    /// Kept separate from <see cref="IMqttService"/> so the login request itself can use an
+    /// unauthenticated HttpClient and the <see cref="BearerTokenHandler"/> can attach tokens
+    /// without recursing through the authenticated client.
+    /// </summary>
+    public interface ITokenProvider
+    {
+        Task<string> GetJwtTokenAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/Services/JwtTokenProvider.cs
+++ b/Services/JwtTokenProvider.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using System.Text.Json;
+using garge_operator.Models;
+using Microsoft.Extensions.Options;
+
+namespace garge_operator.Services
+{
+    /// <summary>
+    /// Fetches and caches the JWT bearer token from garge-api's login endpoint. The login call
+    /// uses a plain, unauthenticated <see cref="HttpClient"/> created from the default factory
+    /// pipeline so it never routes through <see cref="BearerTokenHandler"/> (which would deadlock
+    /// trying to attach a token while fetching one).
+    /// </summary>
+    public class JwtTokenProvider : ITokenProvider
+    {
+        // Named client without the bearer handler, used solely for the unauthenticated login call.
+        public const string LoginClientName = "GargeApiLogin";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ApiOptions _apiOptions;
+        private readonly ILogger<JwtTokenProvider> _logger;
+
+        private string? _cachedToken;
+        private DateTime _tokenExpiry = DateTime.MinValue;
+        private readonly SemaphoreSlim _tokenCacheLock = new(1, 1);
+
+        public JwtTokenProvider(
+            IHttpClientFactory httpClientFactory,
+            IOptions<ApiOptions> apiOptions,
+            ILogger<JwtTokenProvider> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _apiOptions = apiOptions.Value;
+            _logger = logger;
+        }
+
+        public async Task<string> GetJwtTokenAsync(CancellationToken cancellationToken = default)
+        {
+            await _tokenCacheLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_cachedToken != null && DateTime.UtcNow < _tokenExpiry)
+                    return _cachedToken;
+
+                var client = _httpClientFactory.CreateClient(LoginClientName);
+                var loginData = new { Email = _apiOptions.Email, Password = _apiOptions.Password };
+                var content = new StringContent(JsonSerializer.Serialize(loginData), Encoding.UTF8, "application/json");
+                var response = await client.PostAsync($"{_apiOptions.BaseUrl}/api/auth/login", content, cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError("Failed to retrieve JWT token. Status code: {StatusCode}, Reason: {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                    throw new InvalidOperationException("Failed to retrieve JWT token.");
+                }
+
+                var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogDebug("Successfully retrieved JWT token.");
+
+                var tokenResponse = JsonSerializer.Deserialize<JwtTokenResponse>(responseContent);
+                if (tokenResponse == null || string.IsNullOrEmpty(tokenResponse.Token))
+                {
+                    _logger.LogError("JWT token is null or empty.");
+                    throw new InvalidOperationException("Failed to retrieve JWT token.");
+                }
+
+                _cachedToken = tokenResponse.Token;
+                _tokenExpiry = ParseJwtExpiry(_cachedToken).AddSeconds(-60);
+                return _cachedToken;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving JWT token.");
+                throw;
+            }
+            finally
+            {
+                _tokenCacheLock.Release();
+            }
+        }
+
+        private DateTime ParseJwtExpiry(string token)
+        {
+            try
+            {
+                var parts = token.Split('.');
+                if (parts.Length != 3) return DateTime.UtcNow.AddMinutes(14);
+                var padding = (4 - parts[1].Length % 4) % 4;
+                var base64 = parts[1].PadRight(parts[1].Length + padding, '=').Replace('-', '+').Replace('_', '/');
+                var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+                var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("exp", out var expEl) && expEl.TryGetInt64(out var exp))
+                    return DateTimeOffset.FromUnixTimeSeconds(exp).UtcDateTime;
+            }
+            catch (Exception ex)
+            {
+                // Falling back to a conservative default expiry; log so the failure isn't silent.
+                _logger.LogDebug(ex, "Could not parse JWT expiry; using default refresh window.");
+            }
+            return DateTime.UtcNow.AddMinutes(14);
+        }
+    }
+}

--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -7,6 +7,7 @@ using garge_operator.Models;
 using MQTTnet.Packets;
 using garge_operator.Dtos.Mqtt;
 using garge_operator.Constants;
+using Microsoft.Extensions.Options;
 
 namespace garge_operator.Services
 {
@@ -15,7 +16,7 @@ namespace garge_operator.Services
         private readonly IManagedMqttClient _mqttClient;
         private readonly ManagedMqttClientOptions _mqttClientOptions;
         private readonly IHttpClientFactory _httpClientFactory;
-        private readonly IConfiguration _configuration;
+        private readonly ITokenProvider _tokenProvider;
         private readonly ILogger<MqttService> _logger;
         private readonly string _apiBaseUrl;
         private List<Sensor> _sensors;
@@ -47,50 +48,34 @@ namespace garge_operator.Services
             return (now - cmd.SentAt) < graceWindow;
         }
 
-        // JWT token cache
-        private string? _cachedToken;
-        private DateTime _tokenExpiry = DateTime.MinValue;
-        private readonly SemaphoreSlim _tokenCacheLock = new(1, 1);
-
-        public MqttService(IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<MqttService> logger)
+        public MqttService(
+            IHttpClientFactory httpClientFactory,
+            ITokenProvider tokenProvider,
+            IOptions<MqttOptions> mqttOptions,
+            IOptions<ApiOptions> apiOptions,
+            ILogger<MqttService> logger)
         {
             _httpClientFactory = httpClientFactory;
-            _configuration = configuration;
+            _tokenProvider = tokenProvider;
             _logger = logger;
             _sensorUniqIds = new Dictionary<string, string>();
             _switchUniqIds = new Dictionary<string, string>();
             _sensors = new List<Sensor>();
             _switches = new List<Switch>();
 
-            // Read and validate the broker and port.
-            var broker = configuration["Mqtt:Broker"];
-            if (string.IsNullOrWhiteSpace(broker))
-                throw new ArgumentException("Mqtt:Broker not set in configuration.");
-
-            var portString = configuration["Mqtt:Port"];
-            if (!int.TryParse(portString, out var port))
-                throw new ArgumentException("Mqtt:Port is invalid or not set in configuration.");
-
-            // Read and validate the API base URL.
-            var baseUrl = configuration["Api:BaseUrl"];
-            if (string.IsNullOrWhiteSpace(baseUrl))
-                throw new ArgumentException("Api:BaseUrl not set in configuration.");
-            _apiBaseUrl = baseUrl;
-
-            // Read and validate the username and password.
-            var username = configuration["Mqtt:Username"];
-            var password = configuration["Mqtt:Password"];
-            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
-                throw new ArgumentException("Mqtt:Username or Mqtt:Password not set in configuration.");
+            // Configuration is bound and validated at startup (see Program.cs ValidateOnStart),
+            // so the values are guaranteed present here.
+            var mqtt = mqttOptions.Value;
+            _apiBaseUrl = apiOptions.Value.BaseUrl;
 
             var factory = new MqttFactory();
             _mqttClient = factory.CreateManagedMqttClient();
 
             var clientOptions = new MqttClientOptionsBuilder()
                 .WithClientId($"garge-operator-{Guid.NewGuid()}")
-                .WithTcpServer(broker, port)
+                .WithTcpServer(mqtt.Broker, mqtt.Port)
                 .WithTlsOptions(o => { o.UseTls(); })
-                .WithCredentials(username, password)
+                .WithCredentials(mqtt.Username, mqtt.Password)
                 .Build();
 
             _mqttClientOptions = new ManagedMqttClientOptionsBuilder()
@@ -117,10 +102,10 @@ namespace garge_operator.Services
             }
         }
 
-        public async Task ConnectAsync()
+        public async Task ConnectAsync(CancellationToken cancellationToken = default)
         {
             // Ensure login is successful before connecting to MQTT broker.
-            var token = await GetJwtTokenAsync();
+            var token = await _tokenProvider.GetJwtTokenAsync(cancellationToken);
             if (string.IsNullOrEmpty(token))
             {
                 // Without a token MQTT can never authenticate. Throw rather than return so the
@@ -132,10 +117,10 @@ namespace garge_operator.Services
             }
 
             // Get all sensors from the API
-            _sensors = await GetAllSensorsAsync();
+            _sensors = await GetAllSensorsAsync(cancellationToken);
 
             // Get all switches from the API
-            _switches = await GetAllSwitchesAsync();
+            _switches = await GetAllSwitchesAsync(cancellationToken);
 
             // Subscribe to the message received event
             _mqttClient.ApplicationMessageReceivedAsync += HandleReceivedMessage;
@@ -496,23 +481,15 @@ namespace garge_operator.Services
             }
         }
 
-        /// <summary>
-        /// Creates an <see cref="HttpClient"/> with a fresh Bearer token attached.
-        /// Centralizes the token-fetch + factory + Authorization-header boilerplate used by every API call.
-        /// </summary>
-        private async Task<HttpClient> CreateAuthorizedClientAsync()
-        {
-            var token = await GetJwtTokenAsync();
-            var client = _httpClientFactory.CreateClient();
-            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-            return client;
-        }
+        // Resolves the authenticated garge-api client. The JWT bearer is attached automatically
+        // by BearerTokenHandler, so call sites no longer fetch tokens or set headers themselves.
+        private HttpClient CreateApiClient() => _httpClientFactory.CreateClient(GargeApiClient.Authorized);
 
         private async Task<bool> GrantDeviceControlAsync(string granteeDeviceId, string targetDeviceId)
         {
             try
             {
-                var client = await CreateAuthorizedClientAsync();
+                var client = CreateApiClient();
 
                 var topic = GargeTopics.DeviceWildcard(targetDeviceId);
                 bool allSucceeded = true;
@@ -531,8 +508,7 @@ namespace garge_operator.Services
                         Retain = retain ? 1 : 0
                     };
 
-                    var content = new StringContent(JsonSerializer.Serialize(aclPayload), Encoding.UTF8, "application/json");
-                    var response = await client.PostAsync($"{_apiBaseUrl}/api/mqtt/acl", content);
+                    var response = await HttpJson.PostJsonAsync(client, $"{_apiBaseUrl}/api/mqtt/acl", aclPayload);
 
                     if (response.IsSuccessStatusCode)
                     {
@@ -559,10 +535,9 @@ namespace garge_operator.Services
         {
             try
             {
-                var client = await CreateAuthorizedClientAsync();
+                var client = CreateApiClient();
 
-                var content = new StringContent(JsonSerializer.Serialize(devicePayload), Encoding.UTF8, "application/json");
-                var response = await client.PostAsync($"{_apiBaseUrl}/api/mqtt/discovered-device", content);
+                var response = await HttpJson.PostJsonAsync(client, $"{_apiBaseUrl}/api/mqtt/discovered-device", devicePayload);
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -584,9 +559,8 @@ namespace garge_operator.Services
         {
             try
             {
-                var client = await CreateAuthorizedClientAsync();
-                var content = new StringContent(JsonSerializer.Serialize(createSensorData), Encoding.UTF8, "application/json");
-                var response = await client.PostAsync($"{_apiBaseUrl}/api/sensors", content);
+                var client = CreateApiClient();
+                var response = await HttpJson.PostJsonAsync(client, $"{_apiBaseUrl}/api/sensors", createSensorData);
                 response.EnsureSuccessStatusCode();
                 _logger.LogDebug("Successfully created sensor: {SensorName}", createSensorData.Name);
                 return true;
@@ -607,9 +581,8 @@ namespace garge_operator.Services
         {
             try
             {
-                var client = await CreateAuthorizedClientAsync();
-                var content = new StringContent(JsonSerializer.Serialize(createSwitchData), Encoding.UTF8, "application/json");
-                var response = await client.PostAsync($"{_apiBaseUrl}/api/switches", content);
+                var client = CreateApiClient();
+                var response = await HttpJson.PostJsonAsync(client, $"{_apiBaseUrl}/api/switches", createSwitchData);
                 response.EnsureSuccessStatusCode();
                 _logger.LogInformation("Successfully created switch: {SwitchName}", createSwitchData.Name);
                 return true;
@@ -626,12 +599,12 @@ namespace garge_operator.Services
             }
         }
 
-        private async Task<List<Sensor>> GetAllSensorsAsync()
+        private async Task<List<Sensor>> GetAllSensorsAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                var client = await CreateAuthorizedClientAsync();
-                var response = await client.GetAsync($"{_apiBaseUrl}/api/sensors");
+                var client = CreateApiClient();
+                var response = await client.GetAsync($"{_apiBaseUrl}/api/sensors", cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -639,7 +612,7 @@ namespace garge_operator.Services
                     return new List<Sensor>();
                 }
 
-                var responseContent = await response.Content.ReadAsStringAsync();
+                var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 _logger.LogDebug("Sensors response length: {Length}", responseContent.Length);
 
                 var sensors = JsonSerializer.Deserialize<List<Sensor>>(responseContent, JsonOptions);
@@ -662,12 +635,12 @@ namespace garge_operator.Services
             }
         }
 
-        private async Task<List<Switch>> GetAllSwitchesAsync()
+        private async Task<List<Switch>> GetAllSwitchesAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                var client = await CreateAuthorizedClientAsync();
-                var response = await client.GetAsync($"{_apiBaseUrl}/api/switches");
+                var client = CreateApiClient();
+                var response = await client.GetAsync($"{_apiBaseUrl}/api/switches", cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -675,7 +648,7 @@ namespace garge_operator.Services
                     return new List<Switch>();
                 }
 
-                var responseContent = await response.Content.ReadAsStringAsync();
+                var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 _logger.LogDebug("Switches response length: {Length}", responseContent.Length);
 
                 var switches = JsonSerializer.Deserialize<List<Switch>>(responseContent, JsonOptions);
@@ -698,18 +671,16 @@ namespace garge_operator.Services
             }
         }
 
-        private async Task SendDataToApi(string uniqId, string value)
+        private async Task SendDataToApi(string uniqId, string value, CancellationToken cancellationToken = default)
         {
             try
             {
                 _logger.LogInformation("Preparing to send data for sensor {SensorId} to API.", uniqId);
 
-                var client = await CreateAuthorizedClientAsync();
-                var content = new StringContent(JsonSerializer.Serialize(new { value = value }), Encoding.UTF8, "application/json");
-
+                var client = CreateApiClient();
                 var url = $"{_apiBaseUrl}/api/sensors/name/{Uri.EscapeDataString(uniqId)}/data";
                 _logger.LogInformation("Sending data to API: {Url}", url);
-                var response = await client.PostAsync(url, content);
+                var response = await HttpJson.PostJsonAsync(client, url, new { value = value }, cancellationToken);
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -717,7 +688,7 @@ namespace garge_operator.Services
                 }
                 else
                 {
-                    var responseContent = await response.Content.ReadAsStringAsync();
+                    var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                     _logger.LogError("Failed to send data for sensor {SensorId} to API. Status code: {StatusCode}, Reason: {ReasonPhrase}, Response: {ResponseContent}", uniqId, response.StatusCode, response.ReasonPhrase, responseContent);
                 }
             }
@@ -727,18 +698,16 @@ namespace garge_operator.Services
             }
         }
 
-        private async Task SendSwitchDataToApi(string uniqId, string key, string value)
+        private async Task SendSwitchDataToApi(string uniqId, string key, string value, CancellationToken cancellationToken = default)
         {
             try
             {
                 _logger.LogInformation("Preparing to send data for switch {UniqId} to API with key: {Key}", uniqId, key);
 
-                var client = await CreateAuthorizedClientAsync();
-                var content = new StringContent(JsonSerializer.Serialize(new { key, value }), Encoding.UTF8, "application/json");
-
+                var client = CreateApiClient();
                 var url = $"{_apiBaseUrl}/api/switches/name/{Uri.EscapeDataString(uniqId)}/data";
                 _logger.LogInformation("Sending data to API: {Url}", url);
-                var response = await client.PostAsync(url, content);
+                var response = await HttpJson.PostJsonAsync(client, url, new { key, value }, cancellationToken);
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -746,7 +715,7 @@ namespace garge_operator.Services
                 }
                 else
                 {
-                    var responseContent = await response.Content.ReadAsStringAsync();
+                    var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                     _logger.LogError("Failed to send data for switch {UniqId} to API. Status code: {StatusCode}, Reason: {ReasonPhrase}, Response: {ResponseContent}", uniqId, response.StatusCode, response.ReasonPhrase, responseContent);
                 }
             }
@@ -756,70 +725,12 @@ namespace garge_operator.Services
             }
         }
 
-        private DateTime ParseJwtExpiry(string token)
-        {
-            try
-            {
-                var parts = token.Split('.');
-                if (parts.Length != 3) return DateTime.UtcNow.AddMinutes(14);
-                var padding = (4 - parts[1].Length % 4) % 4;
-                var base64 = parts[1].PadRight(parts[1].Length + padding, '=').Replace('-', '+').Replace('_', '/');
-                var json = Encoding.UTF8.GetString(Convert.FromBase64String(base64));
-                var doc = JsonDocument.Parse(json);
-                if (doc.RootElement.TryGetProperty("exp", out var expEl) && expEl.TryGetInt64(out var exp))
-                    return DateTimeOffset.FromUnixTimeSeconds(exp).UtcDateTime;
-            }
-            catch (Exception ex)
-            {
-                // Falling back to a conservative default expiry; log so the failure isn't silent.
-                _logger.LogDebug(ex, "Could not parse JWT expiry; using default refresh window.");
-            }
-            return DateTime.UtcNow.AddMinutes(14);
-        }
-
-        public async Task<string> GetJwtTokenAsync()
-        {
-            await _tokenCacheLock.WaitAsync();
-            try
-            {
-                if (_cachedToken != null && DateTime.UtcNow < _tokenExpiry)
-                    return _cachedToken;
-
-                var client = _httpClientFactory.CreateClient();
-                var loginData = new { Email = _configuration["Api:Email"], Password = _configuration["Api:Password"] };
-                var content = new StringContent(JsonSerializer.Serialize(loginData), Encoding.UTF8, "application/json");
-                var response = await client.PostAsync($"{_apiBaseUrl}/api/auth/login", content);
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    _logger.LogError("Failed to retrieve JWT token. Status code: {StatusCode}, Reason: {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
-                    throw new InvalidOperationException("Failed to retrieve JWT token.");
-                }
-
-                var responseContent = await response.Content.ReadAsStringAsync();
-                _logger.LogDebug("Successfully retrieved JWT token.");
-
-                var tokenResponse = JsonSerializer.Deserialize<JwtTokenResponse>(responseContent);
-                if (tokenResponse == null || string.IsNullOrEmpty(tokenResponse.Token))
-                {
-                    _logger.LogError("JWT token is null or empty.");
-                    throw new InvalidOperationException("Failed to retrieve JWT token.");
-                }
-
-                _cachedToken = tokenResponse.Token;
-                _tokenExpiry = ParseJwtExpiry(_cachedToken).AddSeconds(-60);
-                return _cachedToken;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error retrieving JWT token.");
-                throw;
-            }
-            finally
-            {
-                _tokenCacheLock.Release();
-            }
-        }
+        /// <summary>
+        /// Returns the cached JWT bearer used to authenticate against garge-api. Retained on
+        /// <see cref="IMqttService"/> for callers (for example the SignalR hub access-token
+        /// provider) that need the raw token; the value is sourced from <see cref="ITokenProvider"/>.
+        /// </summary>
+        public Task<string> GetJwtTokenAsync() => _tokenProvider.GetJwtTokenAsync();
 
         public async Task PublishSwitchDataAsync(string topic, string payload)
         {

--- a/Services/OperatorHubClient.cs
+++ b/Services/OperatorHubClient.cs
@@ -1,5 +1,7 @@
+using garge_operator.Models;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace garge_operator.Services
 {
@@ -17,18 +19,18 @@ namespace garge_operator.Services
         private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan ClosedRestartDelay = TimeSpan.FromSeconds(60);
 
-        private readonly IConfiguration _configuration;
+        private readonly string _apiBaseUrl;
         private readonly IMqttService _mqttService;
         private readonly ILogger<OperatorHubClient> _logger;
         private HubConnection? _connection;
         private CancellationToken _stoppingToken;
 
         public OperatorHubClient(
-            IConfiguration configuration,
+            IOptions<ApiOptions> apiOptions,
             IMqttService mqttService,
             ILogger<OperatorHubClient> logger)
         {
-            _configuration = configuration;
+            _apiBaseUrl = apiOptions.Value.BaseUrl;
             _mqttService = mqttService;
             _logger = logger;
         }
@@ -37,9 +39,7 @@ namespace garge_operator.Services
         {
             _stoppingToken = stoppingToken;
 
-            var apiBase = _configuration["Api:BaseUrl"]
-                          ?? throw new InvalidOperationException("Api:BaseUrl not configured");
-            var hubUrl = $"{apiBase.TrimEnd('/')}/hubs/devices";
+            var hubUrl = $"{_apiBaseUrl.TrimEnd('/')}/hubs/devices";
 
             _connection = new HubConnectionBuilder()
                 .WithUrl(hubUrl, opts =>

--- a/Worker.cs
+++ b/Worker.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using garge_operator.Services;
 using garge_operator.Dtos.Automation;
 using garge_operator.Constants;
+using garge_operator.Models;
+using Microsoft.Extensions.Options;
 
 public class Worker : BackgroundService
 {
@@ -11,7 +13,7 @@ public class Worker : BackgroundService
     private readonly ILogger<Worker> _logger;
     private readonly IMqttService _mqttService;
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly IConfiguration _configuration;
+    private readonly string _apiBaseUrl;
 
     // Caches the last published action per switch, keyed by switch ID.
     private readonly Dictionary<int, string> _lastPublishedActions = new();
@@ -23,17 +25,17 @@ public class Worker : BackgroundService
         ILogger<Worker> logger,
         IMqttService mqttService,
         IHttpClientFactory httpClientFactory,
-        IConfiguration configuration)
+        IOptions<ApiOptions> apiOptions)
     {
         _logger = logger;
         _mqttService = mqttService;
         _httpClientFactory = httpClientFactory;
-        _configuration = configuration;
+        _apiBaseUrl = apiOptions.Value.BaseUrl;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await _mqttService.ConnectAsync();
+        await _mqttService.ConnectAsync(stoppingToken);
 
         // Reconcile rule state before entering the poll loop.
         try
@@ -73,8 +75,6 @@ public class Worker : BackgroundService
         var (client, rules) = await FetchRulesAsync(stoppingToken);
         if (client == null || rules == null) return;
 
-        var apiBaseUrl = _configuration["Api:BaseUrl"]!;
-
         foreach (var rule in rules)
         {
             if (!rule.IsEnabled)
@@ -101,21 +101,12 @@ public class Worker : BackgroundService
                         // Timer expired during operator downtime: turn the switch off and clear the timer.
                         _logger.LogInformation("Startup: timer expired for rule {RuleId}, turning OFF and clearing.", rule.Id);
                         await _mqttService.PublishSwitchDataAsync(topic, SwitchActions.Off);
-                        await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{rule.Id}/timer-clear", stoppingToken);
+                        await CallApiPatchAsync(client, $"{_apiBaseUrl}/api/automation/{rule.Id}/timer-clear", stoppingToken);
                     }
                     else
                     {
                         // Timer still active: re-enforce state, gated by the price condition when set.
-                        bool priceOk = true;
-                        if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
-                            rule.ElectricityPriceThreshold.HasValue &&
-                            !string.IsNullOrEmpty(rule.ElectricityPriceArea))
-                        {
-                            var price = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
-                            if (price.HasValue)
-                                priceOk = EvaluateCondition(price.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold.Value);
-                        }
-
+                        var priceOk = await EvaluateTimerPriceGateAsync(client, rule, stoppingToken);
                         var startupDesired = priceOk ? SwitchActions.On : SwitchActions.Off;
                         _logger.LogInformation("Startup: timer active for rule {RuleId}, enforcing '{Action}' (priceOk={PriceOk}).", rule.Id, startupDesired, priceOk);
                         await _mqttService.PublishSwitchDataAsync(topic, startupDesired);
@@ -127,23 +118,11 @@ public class Worker : BackgroundService
             else
             {
                 // Non-timed rule: evaluate the condition and enforce the correct state.
-                var sensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
+                var sensorValue = await GetSensorValueAsync(client, rule.SensorId, stoppingToken);
                 if (sensorValue == null) continue;
 
                 bool conditionMet = EvaluateSensorCondition(sensorValue.Value, rule.Condition, rule.Threshold);
-
-                if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
-                    rule.ElectricityPriceThreshold.HasValue &&
-                    !string.IsNullOrEmpty(rule.ElectricityPriceArea))
-                {
-                    var price = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
-                    if (price.HasValue)
-                    {
-                        var priceConditionMet = EvaluateCondition(price.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold!.Value);
-                        var logicalOp = (rule.ElectricityPriceOperator ?? "AND").ToUpperInvariant();
-                        conditionMet = logicalOp == "OR" ? conditionMet || priceConditionMet : conditionMet && priceConditionMet;
-                    }
-                }
+                conditionMet = await CombineWithPriceConditionAsync(client, rule, conditionMet, stoppingToken);
 
                 if (rule.Action.ToLowerInvariant() != SwitchActions.On && rule.Action.ToLowerInvariant() != SwitchActions.Off)
                 {
@@ -171,8 +150,6 @@ public class Worker : BackgroundService
     {
         var (client, rules) = await FetchRulesAsync(stoppingToken);
         if (client == null || rules == null) return;
-
-        var apiBaseUrl = _configuration["Api:BaseUrl"]!;
 
         _logger.LogInformation("Loaded {Count} automation rules.", rules.Count);
 
@@ -216,21 +193,12 @@ public class Worker : BackgroundService
                         _logger.LogInformation("Rule {RuleId}: timer elapsed ({Elapsed:hh\\:mm}), turning OFF.", rule.Id, elapsed);
                         await _mqttService.PublishSwitchDataAsync(topic, SwitchActions.Off);
                         _lastPublishedActions[rule.TargetId] = SwitchActions.Off;
-                        await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{rule.Id}/timer-clear", stoppingToken);
+                        await CallApiPatchAsync(client, $"{_apiBaseUrl}/api/automation/{rule.Id}/timer-clear", stoppingToken);
                     }
                     else
                     {
                         // Timer still running: gate the socket on the price condition. The sensor only acts as a trigger.
-                        bool priceOk = true;
-                        if (!string.IsNullOrEmpty(rule.ElectricityPriceCondition) &&
-                            rule.ElectricityPriceThreshold.HasValue &&
-                            !string.IsNullOrEmpty(rule.ElectricityPriceArea))
-                        {
-                            var price = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
-                            if (price.HasValue)
-                                priceOk = EvaluateCondition(price.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold.Value);
-                        }
-
+                        var priceOk = await EvaluateTimerPriceGateAsync(client, rule, stoppingToken);
                         var desired = priceOk ? SwitchActions.On : SwitchActions.Off;
                         var last = _lastPublishedActions.GetValueOrDefault(rule.TargetId);
                         if (last != desired)
@@ -244,29 +212,45 @@ public class Worker : BackgroundService
                 }
 
                 // Timer idle: check the trigger condition.
-                var sensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
+                var sensorValue = await GetSensorValueAsync(client, rule.SensorId, stoppingToken);
                 if (sensorValue == null) continue;
 
                 bool conditionMet = EvaluateSensorCondition(sensorValue.Value, rule.Condition, rule.Threshold);
-                conditionMet = await CombineWithPriceConditionAsync(client, apiBaseUrl, rule, conditionMet, stoppingToken);
+                conditionMet = await CombineWithPriceConditionAsync(client, rule, conditionMet, stoppingToken);
 
                 if (conditionMet)
                 {
+                    // BEHAVIOR CHANGE (idempotency, #4): record the timer in the API BEFORE publishing
+                    // "on". Previously the operator published "on" first and only then called
+                    // timer-start; a crash in that window left the switch physically ON while the API
+                    // had no TimerActivatedAt, so the next poll re-evaluated the trigger from scratch
+                    // and double-triggered (restarting the timer, re-publishing, re-marking triggered).
+                    //
+                    // New ordering: call timer-start first and only publish "on" if it succeeded. If the
+                    // process dies after timer-start but before the publish, the next poll sees a non-null
+                    // TimerActivatedAt and enters the "timer running" branch, which idempotently enforces
+                    // the desired (price-gated) state instead of re-triggering. If timer-start fails, we
+                    // skip the publish so the switch is never turned on without recorded timer state.
                     _logger.LogInformation("Rule {RuleId}: condition met, starting {Duration}h timer, turning ON.", rule.Id, rule.TimerDurationHours.Value);
+                    var timerStarted = await CallApiPatchAsync(client, $"{_apiBaseUrl}/api/automation/{rule.Id}/timer-start", stoppingToken);
+                    if (!timerStarted)
+                    {
+                        _logger.LogWarning("Rule {RuleId}: timer-start failed; not publishing ON to keep switch and API state consistent.", rule.Id);
+                        continue;
+                    }
                     await _mqttService.PublishSwitchDataAsync(topic, SwitchActions.On);
                     _lastPublishedActions[rule.TargetId] = SwitchActions.On;
-                    await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{rule.Id}/timer-start", stoppingToken);
-                    await MarkTriggeredAsync(client, apiBaseUrl, rule.Id, stoppingToken);
+                    await MarkTriggeredAsync(client, rule.Id, stoppingToken);
                 }
                 continue;
             }
 
             // ── Standard (non-timed) rule handling ───────────────────────────
-            var stdSensorValue = await GetSensorValueAsync(client, apiBaseUrl, rule.SensorId, stoppingToken);
+            var stdSensorValue = await GetSensorValueAsync(client, rule.SensorId, stoppingToken);
             if (stdSensorValue == null) continue;
 
             bool stdConditionMet = EvaluateSensorCondition(stdSensorValue.Value, rule.Condition, rule.Threshold);
-            stdConditionMet = await CombineWithPriceConditionAsync(client, apiBaseUrl, rule, stdConditionMet, stoppingToken);
+            stdConditionMet = await CombineWithPriceConditionAsync(client, rule, stdConditionMet, stoppingToken);
 
             _logger.LogInformation("Rule {RuleId} conditionMet={ConditionMet}", rule.Id, stdConditionMet);
 
@@ -294,7 +278,7 @@ public class Worker : BackgroundService
             _logger.LogInformation("Publishing action '{Action}' to switch {SwitchName} due to rule {RuleId}.", action, targetSwitch.Name, rule.Id);
             await _mqttService.PublishSwitchDataAsync(topic, action);
             _lastPublishedActions[rule.TargetId] = action;
-            await MarkTriggeredAsync(client, apiBaseUrl, rule.Id, stoppingToken);
+            await MarkTriggeredAsync(client, rule.Id, stoppingToken);
             }
             catch (Exception ex)
             {
@@ -306,24 +290,11 @@ public class Worker : BackgroundService
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
-    /// <summary>
-    /// Creates an <see cref="HttpClient"/> with a fresh Bearer token attached.
-    /// Centralizes the token-fetch + factory + Authorization-header boilerplate.
-    /// </summary>
-    private async Task<HttpClient> CreateAuthorizedClientAsync()
-    {
-        var client = _httpClientFactory.CreateClient();
-        var token = await _mqttService.GetJwtTokenAsync();
-        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-        return client;
-    }
-
     private async Task<(HttpClient? Client, List<AutomationRuleDto>? Rules)> FetchRulesAsync(CancellationToken stoppingToken)
     {
-        var apiBaseUrl = _configuration["Api:BaseUrl"];
-        var client = await CreateAuthorizedClientAsync();
+        var client = _httpClientFactory.CreateClient(GargeApiClient.Authorized);
 
-        var response = await client.GetAsync($"{apiBaseUrl}/api/automation", stoppingToken);
+        var response = await client.GetAsync($"{_apiBaseUrl}/api/automation", stoppingToken);
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogError("Failed to fetch automation rules. Status: {StatusCode}", response.StatusCode);
@@ -341,9 +312,9 @@ public class Worker : BackgroundService
         return (client, rules);
     }
 
-    private async Task<double?> GetSensorValueAsync(HttpClient client, string apiBaseUrl, int sensorId, CancellationToken stoppingToken)
+    private async Task<double?> GetSensorValueAsync(HttpClient client, int sensorId, CancellationToken stoppingToken)
     {
-        var sensorResponse = await client.GetAsync($"{apiBaseUrl}/api/sensors/{sensorId}/latest-data", stoppingToken);
+        var sensorResponse = await client.GetAsync($"{_apiBaseUrl}/api/sensors/{sensorId}/latest-data", stoppingToken);
         if (!sensorResponse.IsSuccessStatusCode)
         {
             _logger.LogWarning("Failed to fetch latest data for sensor {SensorId}. Status: {StatusCode}", sensorId, sensorResponse.StatusCode);
@@ -388,28 +359,59 @@ public class Worker : BackgroundService
         _    => false
     };
 
-    private async Task<bool> CombineWithPriceConditionAsync(HttpClient client, string apiBaseUrl, AutomationRuleDto rule, bool sensorConditionMet, CancellationToken stoppingToken)
+    /// <summary>
+    /// Returns true when a rule has no electricity-price condition configured.
+    /// </summary>
+    private static bool HasPriceCondition(AutomationRuleDto rule)
+        => !string.IsNullOrEmpty(rule.ElectricityPriceCondition)
+           && rule.ElectricityPriceThreshold.HasValue
+           && !string.IsNullOrEmpty(rule.ElectricityPriceArea);
+
+    /// <summary>
+    /// Evaluates the price gate for a running timed rule. The sensor only triggers a timed rule;
+    /// while the timer runs the socket is gated purely on the electricity price. Returns true
+    /// (allow ON) when no price condition is configured or the price could not be fetched, matching
+    /// the historical default. Shared by both the poll loop and startup reconciliation so the two
+    /// paths cannot diverge.
+    /// </summary>
+    private async Task<bool> EvaluateTimerPriceGateAsync(HttpClient client, AutomationRuleDto rule, CancellationToken stoppingToken)
     {
-        if (string.IsNullOrEmpty(rule.ElectricityPriceCondition) ||
-            !rule.ElectricityPriceThreshold.HasValue ||
-            string.IsNullOrEmpty(rule.ElectricityPriceArea))
+        if (!HasPriceCondition(rule))
+            return true;
+
+        var price = await GetCurrentPriceAsync(client, rule.ElectricityPriceArea!, stoppingToken);
+        if (!price.HasValue)
+            return true;
+
+        return EvaluateCondition(price.Value, rule.ElectricityPriceCondition!, rule.ElectricityPriceThreshold!.Value);
+    }
+
+    /// <summary>
+    /// Combines a satisfied sensor condition with the optional electricity-price condition using the
+    /// rule's AND/OR operator. When a price condition is configured but the price cannot be fetched,
+    /// returns false (skip) so the operator never acts on a partially-evaluated rule. Shared by both
+    /// the poll loop and startup reconciliation so the two paths cannot diverge.
+    /// </summary>
+    private async Task<bool> CombineWithPriceConditionAsync(HttpClient client, AutomationRuleDto rule, bool sensorConditionMet, CancellationToken stoppingToken)
+    {
+        if (!HasPriceCondition(rule))
             return sensorConditionMet;
 
-        var currentPrice = await GetCurrentPriceAsync(client, apiBaseUrl, rule.ElectricityPriceArea, stoppingToken);
+        var currentPrice = await GetCurrentPriceAsync(client, rule.ElectricityPriceArea!, stoppingToken);
         if (!currentPrice.HasValue)
         {
             _logger.LogWarning("Rule {RuleId}: could not fetch electricity price for area {Area}, skipping.", rule.Id, rule.ElectricityPriceArea);
             return false;
         }
 
-        var priceConditionMet = EvaluateCondition(currentPrice.Value, rule.ElectricityPriceCondition, rule.ElectricityPriceThreshold.Value);
+        var priceConditionMet = EvaluateCondition(currentPrice.Value, rule.ElectricityPriceCondition!, rule.ElectricityPriceThreshold!.Value);
         _logger.LogInformation("Rule {RuleId} priceConditionMet={Met} (price={Price})", rule.Id, priceConditionMet, currentPrice.Value);
 
         var logicalOp = (rule.ElectricityPriceOperator ?? "AND").ToUpperInvariant();
         return logicalOp == "OR" ? sensorConditionMet || priceConditionMet : sensorConditionMet && priceConditionMet;
     }
 
-    private async Task<double?> GetCurrentPriceAsync(HttpClient client, string apiBaseUrl, string area, CancellationToken stoppingToken)
+    private async Task<double?> GetCurrentPriceAsync(HttpClient client, string area, CancellationToken stoppingToken)
     {
         var now = DateTime.UtcNow;
         if (_priceCache.TryGetValue(area, out var cached) && cached.ValidUntil > now)
@@ -417,7 +419,7 @@ public class Worker : BackgroundService
 
         try
         {
-            var priceResponse = await client.GetAsync($"{apiBaseUrl}/api/electricity/current-price?area={Uri.EscapeDataString(area)}", stoppingToken);
+            var priceResponse = await client.GetAsync($"{_apiBaseUrl}/api/electricity/current-price?area={Uri.EscapeDataString(area)}", stoppingToken);
             if (!priceResponse.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Failed to fetch current price for area {Area}. Status: {StatusCode}", area, priceResponse.StatusCode);
@@ -439,20 +441,30 @@ public class Worker : BackgroundService
         }
     }
 
-    private async Task CallApiPatchAsync(HttpClient client, string url, CancellationToken stoppingToken)
+    /// <summary>
+    /// Issues a PATCH against the API. Returns true when the call succeeds. The boolean result lets
+    /// callers that must keep API and device state consistent (for example timer-start before
+    /// publishing ON) gate the subsequent publish on a recorded state change.
+    /// </summary>
+    private async Task<bool> CallApiPatchAsync(HttpClient client, string url, CancellationToken stoppingToken)
     {
         try
         {
             var response = await client.PatchAsync(url, null, stoppingToken);
             if (!response.IsSuccessStatusCode)
+            {
                 _logger.LogWarning("PATCH {Url} failed with status {StatusCode}.", url, response.StatusCode);
+                return false;
+            }
+            return true;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Could not PATCH {Url}.", url);
+            return false;
         }
     }
 
-    private async Task MarkTriggeredAsync(HttpClient client, string apiBaseUrl, int ruleId, CancellationToken stoppingToken)
-        => await CallApiPatchAsync(client, $"{apiBaseUrl}/api/automation/{ruleId}/triggered", stoppingToken);
+    private async Task MarkTriggeredAsync(HttpClient client, int ruleId, CancellationToken stoppingToken)
+        => await CallApiPatchAsync(client, $"{_apiBaseUrl}/api/automation/{ruleId}/triggered", stoppingToken);
 }

--- a/garge-operator.Tests/FakeHttpMessageHandler.cs
+++ b/garge-operator.Tests/FakeHttpMessageHandler.cs
@@ -6,18 +6,38 @@ public class FakeHttpMessageHandler : HttpMessageHandler
 {
     private readonly List<(Func<HttpRequestMessage, bool> Match, HttpStatusCode Status, string Content)> _rules = new();
 
+    /// <summary>
+    /// Ordered log of every request the handler matched, in "{METHOD} {url}" form. Used by tests
+    /// that assert relative ordering of API calls against MQTT publishes.
+    /// </summary>
+    public List<string> MatchedRequests { get; } = new();
+
+    /// <summary>
+    /// Optional sink invoked with each matched request URL. Tests can point this at the same list a
+    /// mock publish callback writes to, producing a single ordered log that interleaves API calls
+    /// with MQTT publishes so their relative order can be asserted.
+    /// </summary>
+    public Action<string>? OnMatched { get; set; }
+
     public void OnGet(string url, string content, HttpStatusCode status = HttpStatusCode.OK)
         => _rules.Add((r => r.Method == HttpMethod.Get && r.RequestUri!.ToString() == url, status, content));
 
     public void OnPatch(string url, HttpStatusCode status = HttpStatusCode.OK)
         => _rules.Add((r => r.Method == HttpMethod.Patch && r.RequestUri!.ToString() == url, status, "ok"));
 
+    public void OnPost(string url, string content = "ok", HttpStatusCode status = HttpStatusCode.OK)
+        => _rules.Add((r => r.Method == HttpMethod.Post && r.RequestUri!.ToString() == url, status, content));
+
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         foreach (var (match, status, content) in _rules)
         {
             if (match(request))
+            {
+                MatchedRequests.Add($"{request.Method} {request.RequestUri}");
+                OnMatched?.Invoke(request.RequestUri!.ToString());
                 return Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(content) });
+            }
         }
         return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
         {

--- a/garge-operator.Tests/HttpJsonTests.cs
+++ b/garge-operator.Tests/HttpJsonTests.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using System.Text.Json;
+using garge_operator.Services;
+
+namespace garge_operator.Tests;
+
+/// <summary>
+/// Tests for the shared HttpJson.PostJsonAsync helper (refactor #3), which centralizes the
+/// repeated "serialize → StringContent(application/json) → PostAsync" pattern.
+/// </summary>
+public class HttpJsonTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastBody { get; private set; }
+        public HttpStatusCode StatusToReturn { get; set; } = HttpStatusCode.OK;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Observe the token so a cancelled token surfaces, proving it was threaded through.
+            cancellationToken.ThrowIfCancellationRequested();
+            LastRequest = request;
+            LastBody = request.Content == null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(StatusToReturn) { Content = new StringContent("ok") };
+        }
+    }
+
+    [Fact]
+    public async Task PostJsonAsync_SerializesBody_SetsJsonContentType_UsesPost()
+    {
+        var handler = new CapturingHandler();
+        using var client = new HttpClient(handler);
+        var body = new { value = "42", nested = new { area = "NO1" } };
+
+        var response = await HttpJson.PostJsonAsync(client, "http://api/sensors/data", body);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest!.Method);
+        Assert.Equal("http://api/sensors/data", handler.LastRequest.RequestUri!.ToString());
+        Assert.Equal("application/json", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
+
+        // The serialized body must match plain JsonSerializer output for the same value.
+        Assert.Equal(JsonSerializer.Serialize(body), handler.LastBody);
+    }
+
+    [Fact]
+    public async Task PostJsonAsync_ReturnsResponse_OnNonSuccessStatus_WithoutThrowing()
+    {
+        var handler = new CapturingHandler { StatusToReturn = HttpStatusCode.Conflict };
+        using var client = new HttpClient(handler);
+
+        var response = await HttpJson.PostJsonAsync(client, "http://api/switches", new { name = "s1" });
+
+        // The helper only performs the request; success/error branching stays with the caller.
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostJsonAsync_PropagatesCancellationToken()
+    {
+        var handler = new CapturingHandler();
+        using var client = new HttpClient(handler);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // An already-cancelled token must surface as a cancellation, proving the token is threaded
+        // through to the underlying request rather than ignored.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => HttpJson.PostJsonAsync(client, "http://api/x", new { a = 1 }, cts.Token));
+    }
+}

--- a/garge-operator.Tests/WorkerSharedPriceLogicTests.cs
+++ b/garge-operator.Tests/WorkerSharedPriceLogicTests.cs
@@ -1,0 +1,156 @@
+using Moq;
+
+namespace garge_operator.Tests;
+
+/// <summary>
+/// Pins the price-gating logic that is now shared between PollAutomationsAsync and
+/// ReconcileOnStartupAsync (refactor #5). Each scenario is run through BOTH entry points using the
+/// same setup, asserting identical outcomes so the two paths cannot silently diverge again. The
+/// shared helpers under test are EvaluateTimerPriceGateAsync (running timed rules) and
+/// CombineWithPriceConditionAsync (non-timed rules).
+/// </summary>
+public class WorkerSharedPriceLogicTests : WorkerTestBase
+{
+    public enum Path { Poll, Reconcile }
+
+    private Task Run(Path path, Worker worker) => path switch
+    {
+        Path.Poll => worker.PollAutomationsAsync(CancellationToken.None),
+        Path.Reconcile => worker.ReconcileOnStartupAsync(CancellationToken.None),
+        _ => throw new ArgumentOutOfRangeException(nameof(path)),
+    };
+
+    // ── Running timed rule: price gate (EvaluateTimerPriceGateAsync) ──────────
+
+    [Theory]
+    [InlineData(Path.Poll)]
+    [InlineData(Path.Reconcile)]
+    public async Task RunningTimer_PriceBelowThreshold_EnforcesOn(Path path)
+    {
+        var rule = MakeRule(targetId: 10, timerDurationHours: 2,
+            timerActivatedAt: DateTime.UtcNow.AddMinutes(-30),
+            priceCondition: "<", priceThreshold: 0.5, priceArea: "NO1");
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        SetupPrice("NO1", price: 0.3);
+
+        await Run(path, CreateWorker());
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync("garge/devices/test-socket/set", "on"), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(Path.Poll)]
+    [InlineData(Path.Reconcile)]
+    public async Task RunningTimer_PriceAboveThreshold_EnforcesOff(Path path)
+    {
+        var rule = MakeRule(targetId: 10, timerDurationHours: 2,
+            timerActivatedAt: DateTime.UtcNow.AddMinutes(-30),
+            priceCondition: "<", priceThreshold: 0.5, priceArea: "NO1");
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        // Poll only publishes on change, so seed "on" as the last action via reconcile-like state.
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string> { ["test-socket"] = "on" });
+        SetupPrice("NO1", price: 1.0);
+
+        await Run(path, CreateWorker());
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync("garge/devices/test-socket/set", "off"), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(Path.Poll)]
+    [InlineData(Path.Reconcile)]
+    public async Task RunningTimer_NoPriceCondition_EnforcesOn(Path path)
+    {
+        // With no price condition the gate defaults to allow-ON for both paths.
+        var rule = MakeRule(targetId: 10, timerDurationHours: 2,
+            timerActivatedAt: DateTime.UtcNow.AddMinutes(-30));
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+
+        await Run(path, CreateWorker());
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync("garge/devices/test-socket/set", "on"), Times.Once);
+    }
+
+    // ── Non-timed rule: combine (CombineWithPriceConditionAsync) ─────────────
+
+    [Theory]
+    [InlineData(Path.Poll)]
+    [InlineData(Path.Reconcile)]
+    public async Task NonTimed_PriceAnd_BothMet_PublishesOn(Path path)
+    {
+        var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20, action: "on",
+            priceCondition: "<", priceThreshold: 0.5, priceArea: "NO1", priceOperator: "AND");
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        SetupSensor(5, value: 25);
+        SetupPrice("NO1", price: 0.3);
+        HttpHandler.OnPatch($"{ApiBase}/api/automation/1/triggered");
+
+        await Run(path, CreateWorker());
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync("garge/devices/test-socket/set", "on"), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(Path.Poll)]
+    [InlineData(Path.Reconcile)]
+    public async Task NonTimed_PriceAnd_PriceNotMet_DoesNotPublish(Path path)
+    {
+        var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20, action: "on",
+            priceCondition: "<", priceThreshold: 0.5, priceArea: "NO1", priceOperator: "AND");
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        SetupSensor(5, value: 25);
+        SetupPrice("NO1", price: 1.0);
+
+        await Run(path, CreateWorker());
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(Path.Poll)]
+    [InlineData(Path.Reconcile)]
+    public async Task NonTimed_PriceOr_OnlyPriceMet_PublishesOn(Path path)
+    {
+        var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20, action: "on",
+            priceCondition: "<", priceThreshold: 0.5, priceArea: "NO1", priceOperator: "OR");
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        SetupSensor(5, value: 15); // Sensor condition not met.
+        SetupPrice("NO1", price: 0.3); // Price condition met.
+        HttpHandler.OnPatch($"{ApiBase}/api/automation/1/triggered");
+
+        await Run(path, CreateWorker());
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync("garge/devices/test-socket/set", "on"), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(Path.Poll)]
+    [InlineData(Path.Reconcile)]
+    public async Task NonTimed_PriceConfigured_PriceFetchFails_DoesNotPublish(Path path)
+    {
+        // When a price condition is configured but the price endpoint fails, the shared combine
+        // helper returns false for BOTH paths (no partial-condition action). No price handler is
+        // registered, so the fetch returns 404.
+        var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20, action: "on",
+            priceCondition: "<", priceThreshold: 0.5, priceArea: "NO1", priceOperator: "AND");
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        SetupSensor(5, value: 25);
+
+        await Run(path, CreateWorker());
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/garge-operator.Tests/WorkerTestBase.cs
+++ b/garge-operator.Tests/WorkerTestBase.cs
@@ -1,8 +1,9 @@
 using System.Text.Json;
 using garge_operator.Dtos.Automation;
+using garge_operator.Models;
 using garge_operator.Services;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace garge_operator.Tests;
@@ -19,10 +20,8 @@ public abstract class WorkerTestBase
         var client = new HttpClient(HttpHandler);
         var factory = new Mock<IHttpClientFactory>();
         factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?> { ["Api:BaseUrl"] = ApiBase })
-            .Build();
-        return new Worker(NullLogger<Worker>.Instance, MockMqtt.Object, factory.Object, config);
+        var apiOptions = Options.Create(new ApiOptions { BaseUrl = ApiBase });
+        return new Worker(NullLogger<Worker>.Instance, MockMqtt.Object, factory.Object, apiOptions);
     }
 
     protected void SetupRules(params AutomationRuleDto[] rules)

--- a/garge-operator.Tests/WorkerTimerIdempotencyTests.cs
+++ b/garge-operator.Tests/WorkerTimerIdempotencyTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using Moq;
+
+namespace garge_operator.Tests;
+
+/// <summary>
+/// Tests for the timer-start ordering / idempotency fix (refactor #4).
+///
+/// Before: a timed rule firing published "on" first and only then called the API timer-start.
+/// A crash between those two steps left the switch physically ON while the API had no
+/// TimerActivatedAt, so the next poll re-evaluated the trigger and double-triggered.
+///
+/// After: the operator calls timer-start first and publishes "on" only if timer-start succeeded.
+/// A crash after timer-start but before the publish leaves the API with TimerActivatedAt set, so
+/// the next poll takes the idempotent "timer running" branch instead of re-triggering.
+/// </summary>
+public class WorkerTimerIdempotencyTests : WorkerTestBase
+{
+    [Fact]
+    public async Task TimerIdle_ConditionMet_OrderingIsTimerStartThenPublish()
+    {
+        // Single shared event log captures both the API timer-start and the MQTT publish so their
+        // relative order can be asserted directly.
+        var events = new List<string>();
+
+        var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20, timerDurationHours: 2);
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        SetupSensor(5, value: 25);
+
+        HttpHandler.OnPatch($"{ApiBase}/api/automation/1/timer-start");
+        HttpHandler.OnPatch($"{ApiBase}/api/automation/1/triggered");
+
+        // Record the API timer-start and the MQTT publish into the same ordered log.
+        HttpHandler.OnMatched = url =>
+        {
+            if (url == $"{ApiBase}/api/automation/1/timer-start") events.Add("timer-start");
+        };
+        MockMqtt.Setup(m => m.PublishSwitchDataAsync("garge/devices/test-socket/set", "on"))
+            .Callback(() => events.Add("publish:on"))
+            .Returns(Task.CompletedTask);
+
+        var worker = CreateWorker();
+
+        await worker.PollAutomationsAsync(CancellationToken.None);
+
+        // timer-start must be recorded before the publish (the behavior change).
+        Assert.Equal(new[] { "timer-start", "publish:on" }, events);
+    }
+
+    [Fact]
+    public async Task TimerIdle_ConditionMet_TimerStartFails_DoesNotPublish()
+    {
+        var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20, timerDurationHours: 2);
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        SetupSensor(5, value: 25);
+        // timer-start fails: the switch must NOT be turned on, keeping device and API state consistent.
+        HttpHandler.OnPatch($"{ApiBase}/api/automation/1/timer-start", HttpStatusCode.InternalServerError);
+        var worker = CreateWorker();
+
+        await worker.PollAutomationsAsync(CancellationToken.None);
+
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        // triggered must not be marked either, since nothing was actually triggered.
+        Assert.DoesNotContain(HttpHandler.MatchedRequests, r => r.Contains("/triggered"));
+    }
+
+    [Fact]
+    public async Task CrashAfterTimerStartBeforePublish_NextPoll_DoesNotDoubleTrigger()
+    {
+        // Models the post-crash state the new ordering guarantees: timer-start succeeded (so the API
+        // now reports TimerActivatedAt), but the process died before the publish. On the next poll
+        // the rule has a non-null TimerActivatedAt within its window, so it enters the idempotent
+        // "timer running" branch — it must NOT call timer-start again or re-mark triggered.
+        var activatedAt = DateTime.UtcNow.AddMinutes(-1);
+        var rule = MakeRule(targetId: 10, sensorId: 5, condition: ">", threshold: 20,
+            timerDurationHours: 2, timerActivatedAt: activatedAt);
+        SetupRules(rule);
+        MockMqtt.Setup(m => m.GetSwitch(10)).Returns(MakeSocket());
+        MockMqtt.Setup(m => m.LastPublishedSwitchStates).Returns(new Dictionary<string, string>());
+        var worker = CreateWorker();
+
+        await worker.PollAutomationsAsync(CancellationToken.None);
+
+        // It idempotently enforces the desired (no price gate → ON) state once...
+        MockMqtt.Verify(m => m.PublishSwitchDataAsync("garge/devices/test-socket/set", "on"), Times.Once);
+        // ...but it must NOT re-trigger: no second timer-start and no triggered mark.
+        Assert.DoesNotContain(HttpHandler.MatchedRequests, r => r.Contains("/timer-start"));
+        Assert.DoesNotContain(HttpHandler.MatchedRequests, r => r.Contains("/triggered"));
+    }
+}


### PR DESCRIPTION
## Summary

Deferred refactors + one intentional correctness fix (timer-start ordering, see below).

- Bind Mqtt/Api config to validated IOptions POCOs (ValidateOnStart); remove scattered stringly-typed reads and duplicate Api:BaseUrl lookups. Config keys/structure unchanged.
- Replace the manual auth-client helper with a BearerTokenHandler DelegatingHandler on a named HttpClient; token fetch/caching moves to JwtTokenProvider (login uses a separate unauthenticated client to avoid handler recursion)
- Add generic HttpJson.PostJsonAsync; centralizes serialize/content-type/error logging
- Share price-gate + combine logic between the poll and reconcile paths (one helper, cannot diverge)
- Thread CancellationToken through HTTP helpers + ConnectAsync

Build clean (0 warnings, 0 errors). Tests: 95 pass (75 prior + 20 new).

## Behavior change - timer-start ordering (#4)

Before: timed rule fires -> publish on -> PATCH timer-start -> mark triggered. A crash between publish and timer-start left the switch physically ON with no TimerActivatedAt in the API, so the next poll re-entered the idle branch and double-triggered.

After: PATCH timer-start first -> publish on only if timer-start succeeded -> mark triggered. If timer-start fails, publish is skipped (switch never goes ON without recorded timer state). A crash after timer-start now leaves TimerActivatedAt set, so the next poll takes the idempotent running branch instead of re-triggering. Covered by 3 tests.

Consequential #5 delta: to share one combine helper, reconcile non-timed path now skips on price-fetch failure (was lenient/left untouched), matching poll existing behavior. Safer (never act on a partially-evaluated rule); pinned by a test across both paths.