### PR TITLE
test: cover options ValidateOnStart, bearer handler, ConnectAsync fail-fast

### DIFF
--- a/garge-operator.Tests/BearerTokenHandlerTests.cs
+++ b/garge-operator.Tests/BearerTokenHandlerTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using garge_operator.Services;
+using Moq;
+
+namespace garge_operator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="BearerTokenHandler"/>, the DelegatingHandler that attaches the JWT
+/// bearer to every outgoing request on the authenticated garge-api client. The handler is wired
+/// with a fake <see cref="ITokenProvider"/> and a capturing inner handler, then driven through an
+/// <see cref="HttpClient"/> so the Authorization header on the actual outgoing request can be
+/// asserted — including that a refreshed token replaces the previous one on a later send.
+/// </summary>
+public class BearerTokenHandlerTests
+{
+    // Records the Authorization header seen on each request reaching the inner handler.
+    private sealed class CapturingInnerHandler : HttpMessageHandler
+    {
+        public List<string?> SeenAuthorizationHeaders { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            SeenAuthorizationHeaders.Add(request.Headers.Authorization?.ToString());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok")
+            });
+        }
+    }
+
+    private static HttpClient BuildClient(ITokenProvider provider, out CapturingInnerHandler inner)
+    {
+        inner = new CapturingInnerHandler();
+        var handler = new BearerTokenHandler(provider) { InnerHandler = inner };
+        return new HttpClient(handler);
+    }
+
+    [Fact]
+    public async Task SendAsync_AttachesBearerTokenFromProvider()
+    {
+        var tokenProvider = new Mock<ITokenProvider>();
+        tokenProvider.Setup(p => p.GetJwtTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("test-token-123");
+        using var client = BuildClient(tokenProvider.Object, out var inner);
+
+        var response = await client.GetAsync("http://api/anything");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(new[] { "Bearer test-token-123" }, inner.SeenAuthorizationHeaders);
+    }
+
+    [Fact]
+    public async Task SendAsync_RequestsTokenOncePerSend()
+    {
+        var tokenProvider = new Mock<ITokenProvider>();
+        tokenProvider.Setup(p => p.GetJwtTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("test-token-123");
+        using var client = BuildClient(tokenProvider.Object, out _);
+
+        await client.GetAsync("http://api/anything");
+
+        // The header is set exactly once per request: the provider is consulted a single time and
+        // there is no double-attach.
+        tokenProvider.Verify(p => p.GetJwtTokenAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendAsync_SecondSend_UsesRefreshedToken()
+    {
+        // The provider returns a refreshed token on the second call (mirrors cache expiry). Each
+        // send must carry the token current at that moment — the header is overwritten, not appended.
+        var tokenProvider = new Mock<ITokenProvider>();
+        tokenProvider.SetupSequence(p => p.GetJwtTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("token-old")
+            .ReturnsAsync("token-new");
+        using var client = BuildClient(tokenProvider.Object, out var inner);
+
+        await client.GetAsync("http://api/first");
+        await client.GetAsync("http://api/second");
+
+        Assert.Equal(
+            new[] { "Bearer token-old", "Bearer token-new" },
+            inner.SeenAuthorizationHeaders);
+    }
+
+    [Fact]
+    public async Task SendAsync_ThreadsCancellationTokenToProvider()
+    {
+        // The handler must thread the (linked) request cancellation token through to the token
+        // provider. HttpClient links the caller's token with its own, so identity cannot be
+        // asserted; instead a provider that observes cancellation proves the token reached it: an
+        // already-cancelled request surfaces as a cancellation rather than being ignored.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var tokenProvider = new Mock<ITokenProvider>();
+        tokenProvider.Setup(p => p.GetJwtTokenAsync(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult("scoped-token");
+            });
+        using var client = BuildClient(tokenProvider.Object, out var inner);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://api/scoped");
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.SendAsync(request, cts.Token));
+        // The request never reached the inner handler because the token fetch was cancelled first.
+        Assert.Empty(inner.SeenAuthorizationHeaders);
+    }
+}

--- a/garge-operator.Tests/MqttServiceConnectTests.cs
+++ b/garge-operator.Tests/MqttServiceConnectTests.cs
@@ -1,0 +1,63 @@
+using garge_operator.Models;
+using garge_operator.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace garge_operator.Tests;
+
+/// <summary>
+/// Tests the fail-fast guard at the top of <see cref="MqttService.ConnectAsync"/>: without a usable
+/// JWT the operator must throw rather than continue connecting deaf. Paired with
+/// BackgroundServiceExceptionBehavior.StopHost (Program.cs), throwing causes the pod to exit and be
+/// rescheduled instead of running forever with a dead MQTT connection. The MQTT client itself is
+/// never started in these tests — the token check runs before any broker interaction.
+/// </summary>
+public class MqttServiceConnectTests
+{
+    private static MqttService CreateService(ITokenProvider tokenProvider)
+    {
+        var factory = new Mock<IHttpClientFactory>();
+        // Connect should fail at the token check before any HttpClient is needed, so a default
+        // (unconfigured) factory is sufficient.
+        var mqttOptions = Options.Create(new MqttOptions
+        {
+            Broker = "broker.example.com",
+            Port = 8883,
+            Username = "user",
+            Password = "pass",
+        });
+        var apiOptions = Options.Create(new ApiOptions { BaseUrl = "http://test-api" });
+
+        return new MqttService(
+            factory.Object,
+            tokenProvider,
+            mqttOptions,
+            apiOptions,
+            NullLogger<MqttService>.Instance);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_EmptyToken_ThrowsInvalidOperationException()
+    {
+        var tokenProvider = new Mock<ITokenProvider>();
+        tokenProvider.Setup(p => p.GetJwtTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(string.Empty);
+        var service = CreateService(tokenProvider.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ConnectAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_NullToken_ThrowsInvalidOperationException()
+    {
+        var tokenProvider = new Mock<ITokenProvider>();
+        tokenProvider.Setup(p => p.GetJwtTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string)null!);
+        var service = CreateService(tokenProvider.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ConnectAsync(CancellationToken.None));
+    }
+}

--- a/garge-operator.Tests/OptionsValidationTests.cs
+++ b/garge-operator.Tests/OptionsValidationTests.cs
@@ -1,0 +1,168 @@
+using garge_operator.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace garge_operator.Tests;
+
+/// <summary>
+/// Pins the startup configuration-validation wiring from Program.cs:
+/// <c>AddOptions&lt;T&gt;().Bind(section).ValidateDataAnnotations().ValidateOnStart()</c>.
+/// Each test rebuilds that pipeline against an in-memory <see cref="IConfiguration"/> so the
+/// DataAnnotations on <see cref="MqttOptions"/> and <see cref="ApiOptions"/> are exercised through
+/// the same path the host uses. With ValidateOnStart, missing or blank required keys must surface
+/// as an eager <see cref="OptionsValidationException"/> rather than a lazy failure on first use.
+/// </summary>
+public class OptionsValidationTests
+{
+    // Mirrors Program.cs: bind both options sections from configuration with DataAnnotation
+    // validation enforced at startup, then build the provider so ValidateOnStart can run.
+    private static ServiceProvider BuildProvider(IDictionary<string, string?> settings)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        var services = new ServiceCollection();
+
+        services.AddOptions<MqttOptions>()
+            .Bind(configuration.GetSection(MqttOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddOptions<ApiOptions>()
+            .Bind(configuration.GetSection(ApiOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        return services.BuildServiceProvider();
+    }
+
+    private static Dictionary<string, string?> ValidSettings() => new()
+    {
+        ["Mqtt:Broker"] = "broker.example.com",
+        ["Mqtt:Port"] = "8883",
+        ["Mqtt:Username"] = "mqtt-user",
+        ["Mqtt:Password"] = "mqtt-pass",
+        ["Api:BaseUrl"] = "http://api.example.com",
+        ["Api:Email"] = "ops@example.com",
+        ["Api:Password"] = "api-pass",
+    };
+
+    // Resolving IOptions<T>.Value runs DataAnnotation validation lazily; ValidateOnStart wires the
+    // same validation into host startup. Touching .Value here reproduces the validation that
+    // ValidateOnStart performs eagerly, without needing to spin up a full host.
+    private static T Resolve<T>(ServiceProvider provider) where T : class
+        => provider.GetRequiredService<IOptions<T>>().Value;
+
+    // ── All required keys present → resolution succeeds ──────────────────────
+
+    [Fact]
+    public void AllKeysPresent_MqttOptions_Resolves()
+    {
+        using var provider = BuildProvider(ValidSettings());
+
+        var options = Resolve<MqttOptions>(provider);
+
+        Assert.Equal("broker.example.com", options.Broker);
+        Assert.Equal(8883, options.Port);
+        Assert.Equal("mqtt-user", options.Username);
+        Assert.Equal("mqtt-pass", options.Password);
+    }
+
+    [Fact]
+    public void AllKeysPresent_ApiOptions_Resolves()
+    {
+        using var provider = BuildProvider(ValidSettings());
+
+        var options = Resolve<ApiOptions>(provider);
+
+        Assert.Equal("http://api.example.com", options.BaseUrl);
+    }
+
+    // ── Missing / blank required keys → OptionsValidationException ────────────
+
+    [Theory]
+    [InlineData("Mqtt:Broker")]
+    [InlineData("Mqtt:Username")]
+    [InlineData("Mqtt:Password")]
+    public void MqttOptions_RequiredStringMissing_Throws(string keyToRemove)
+    {
+        var settings = ValidSettings();
+        settings.Remove(keyToRemove);
+        using var provider = BuildProvider(settings);
+
+        Assert.Throws<OptionsValidationException>(() => Resolve<MqttOptions>(provider));
+    }
+
+    [Theory]
+    [InlineData("Mqtt:Broker")]
+    [InlineData("Mqtt:Username")]
+    [InlineData("Mqtt:Password")]
+    public void MqttOptions_RequiredStringBlank_Throws(string keyToBlank)
+    {
+        var settings = ValidSettings();
+        settings[keyToBlank] = "";
+        using var provider = BuildProvider(settings);
+
+        Assert.Throws<OptionsValidationException>(() => Resolve<MqttOptions>(provider));
+    }
+
+    [Fact]
+    public void MqttOptions_PortMissing_DefaultsToZero_OutOfRange_Throws()
+    {
+        // No Mqtt:Port binds the default 0, which is outside the [1, 65535] Range constraint.
+        var settings = ValidSettings();
+        settings.Remove("Mqtt:Port");
+        using var provider = BuildProvider(settings);
+
+        Assert.Throws<OptionsValidationException>(() => Resolve<MqttOptions>(provider));
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("65536")]
+    public void MqttOptions_PortOutOfRange_Throws(string port)
+    {
+        var settings = ValidSettings();
+        settings["Mqtt:Port"] = port;
+        using var provider = BuildProvider(settings);
+
+        Assert.Throws<OptionsValidationException>(() => Resolve<MqttOptions>(provider));
+    }
+
+    [Fact]
+    public void ApiOptions_BaseUrlMissing_Throws()
+    {
+        var settings = ValidSettings();
+        settings.Remove("Api:BaseUrl");
+        using var provider = BuildProvider(settings);
+
+        Assert.Throws<OptionsValidationException>(() => Resolve<ApiOptions>(provider));
+    }
+
+    [Fact]
+    public void ApiOptions_BaseUrlBlank_Throws()
+    {
+        var settings = ValidSettings();
+        settings["Api:BaseUrl"] = "";
+        using var provider = BuildProvider(settings);
+
+        Assert.Throws<OptionsValidationException>(() => Resolve<ApiOptions>(provider));
+    }
+
+    [Fact]
+    public void ApiOptions_OptionalEmailAndPasswordMissing_StillResolves()
+    {
+        // Email and Password are optional (nullable, no [Required]); only BaseUrl is mandatory.
+        var settings = ValidSettings();
+        settings.Remove("Api:Email");
+        settings.Remove("Api:Password");
+        using var provider = BuildProvider(settings);
+
+        var options = Resolve<ApiOptions>(provider);
+
+        Assert.Equal("http://api.example.com", options.BaseUrl);
+        Assert.Null(options.Email);
+        Assert.Null(options.Password);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up test coverage for the merged refactors (#138). Test code only, no production changes.

- Config validation: Mqtt/Api options bound + ValidateOnStart throw OptionsValidationException on missing/blank/out-of-range required keys; resolve cleanly when complete
- BearerTokenHandler attaches Authorization: Bearer, consults the token provider once per send, and uses the refreshed token on the next send (no double-add)
- ConnectAsync throws InvalidOperationException on empty/null token (the don't-run-deaf guard)

Tests: 115 pass (95 prior + 20).