### PR TITLE
chore: relicense MIT to proprietary (all rights reserved)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,14 @@
-MIT License
+Copyright (c) 2023-2026 Sondre SjÃ¸lyst. All rights reserved.
 
-Copyright (c) 2025 Sondre Sjølyst
+This software and its source code (the "Software") are made publicly viewable
+for reference and transparency only. No license or right to use, copy, modify,
+merge, publish, distribute, sublicense, or sell the Software, in whole or in
+part, is granted, whether express or implied, except by a separate written
+agreement signed by the copyright holder.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Viewing the Software via the hosting platform does not grant any rights beyond
+those required by that platform's terms of service. No fork, derivative work,
+or contribution may be used or distributed without prior written permission.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Replace the MIT license with a proprietary, all-rights-reserved license. Source remains publicly viewable; no use, copy, modification, or distribution is permitted without a separate written agreement. Commits published before this change remain under MIT for those versions.