### PR TITLE
feat: forward device pairing tokens to claim API

### DIFF
--- a/Dtos/Mqtt/PairingPayload.cs
+++ b/Dtos/Mqtt/PairingPayload.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace garge_operator.Dtos.Mqtt
+{
+    /// <summary>
+    /// One-shot pairing message published by a device during setup.
+    /// Expected format: { "token": "ABC123" }
+    /// </summary>
+    public class PairingPayload
+    {
+        [JsonPropertyName("token")]
+        public string? Token { get; set; }
+    }
+}

--- a/Models/MqttOptions.cs
+++ b/Models/MqttOptions.cs
@@ -24,5 +24,11 @@ namespace garge_operator.Models
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Mqtt:Username or Mqtt:Password not set in configuration.")]
         public string Password { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Local-development escape hatch: accept broker certificates that fail chain validation
+        /// (e.g. antivirus TLS interception on a dev machine). Never enable in production.
+        /// </summary>
+        public bool AllowUntrustedCertificates { get; set; }
     }
 }

--- a/Models/PairingClaimResponse.cs
+++ b/Models/PairingClaimResponse.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace garge_operator.Models
+{
+    /// <summary>
+    /// Success body returned by <c>POST /api/pairing/claim</c>.
+    /// </summary>
+    public class PairingClaimResponse
+    {
+        [JsonPropertyName("claimedSensorIds")]
+        public List<int>? ClaimedSensorIds { get; set; }
+
+        [JsonPropertyName("claimedSwitchIds")]
+        public List<int>? ClaimedSwitchIds { get; set; }
+
+        [JsonPropertyName("skipped")]
+        public int? Skipped { get; set; }
+    }
+}

--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -37,6 +37,12 @@ namespace garge_operator.Services
         private readonly Dictionary<string, (string Action, DateTime SentAt)> _lastCommandedAt = new();
         internal static readonly TimeSpan CommandEchoGrace = TimeSpan.FromSeconds(30);
 
+        // A pairing claim can race the device's config handling: the API answers 404 while no
+        // sensor/switch rows exist yet for the parent, so the claim is retried a few times
+        // before giving up. 400/410 mean the token itself is bad and are never retried.
+        internal const int PairingClaimMaxRetries = 5;
+        internal static readonly TimeSpan PairingClaimRetryDelay = TimeSpan.FromSeconds(3);
+
         internal static bool IsPreSwitchEcho(
             string incomingState,
             (string Action, DateTime SentAt)? lastCommand,
@@ -74,7 +80,16 @@ namespace garge_operator.Services
             var clientOptions = new MqttClientOptionsBuilder()
                 .WithClientId($"garge-operator-{Guid.NewGuid()}")
                 .WithTcpServer(mqtt.Broker, mqtt.Port)
-                .WithTlsOptions(o => { o.UseTls(); })
+                .WithTlsOptions(o =>
+                {
+                    o.UseTls();
+                    if (mqtt.AllowUntrustedCertificates)
+                    {
+                        _logger.LogWarning("MQTT TLS certificate validation is DISABLED (Mqtt:AllowUntrustedCertificates) — dev use only.");
+                        o.WithAllowUntrustedCertificates(true);
+                        o.WithCertificateValidationHandler(_ => true);
+                    }
+                })
                 .WithCredentials(mqtt.Username, mqtt.Password)
                 .Build();
 
@@ -139,9 +154,10 @@ namespace garge_operator.Services
                         new MqttTopicFilterBuilder().WithTopic("garge/devices/+/+/config").Build(),
                         new MqttTopicFilterBuilder().WithTopic("garge/devices/+/+/state").Build(),
                         new MqttTopicFilterBuilder().WithTopic("garge/devices/+/+/set").Build(),
+                        new MqttTopicFilterBuilder().WithTopic("garge/devices/+/pairing").Build(),
                         new MqttTopicFilterBuilder().WithTopic("garge/devices/+/discovered_devices/+/discovered").Build()
                     });
-                    _logger.LogInformation("Subscribed to garge/devices/+/config, garge/devices/+/+/config, state, set topics and device discovery events.");
+                    _logger.LogInformation("Subscribed to garge/devices/+/config, garge/devices/+/+/config, state, set, pairing topics and device discovery events.");
                 }
                 catch (Exception ex)
                 {
@@ -350,6 +366,10 @@ namespace garge_operator.Services
                             _logger.LogWarning("Entity {Entity} not found in switch or sensor lists.", entity);
                         }
                         break;
+
+                    case "pairing":
+                        await HandleDevicePairing(deviceId, payload);
+                        break;
                 }
             }
             catch (JsonException ex)
@@ -478,6 +498,135 @@ namespace garge_operator.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error handling switch config.");
+            }
+        }
+
+        /// <summary>
+        /// Extracts the pairing token from a pairing payload. The payload is normally JSON of the
+        /// form <c>{"token":"ABC123"}</c>, but a plain-string payload is tolerated: when JSON
+        /// parsing fails, the trimmed payload itself is treated as the token.
+        /// </summary>
+        internal static bool TryParsePairingToken(string payload, out string token)
+        {
+            token = string.Empty;
+            if (string.IsNullOrWhiteSpace(payload)) return false;
+
+            try
+            {
+                var parsed = JsonSerializer.Deserialize<PairingPayload>(payload, JsonOptions);
+                token = parsed?.Token?.Trim() ?? string.Empty;
+            }
+            catch (JsonException)
+            {
+                token = payload.Trim();
+            }
+
+            return !string.IsNullOrEmpty(token);
+        }
+
+        private async Task HandleDevicePairing(string deviceName, string payload)
+        {
+            try
+            {
+                if (!IsValidDeviceId(deviceName))
+                {
+                    _logger.LogWarning("Rejecting pairing message with invalid device name: {DeviceName}", deviceName);
+                    return;
+                }
+
+                if (!TryParsePairingToken(payload, out var token))
+                {
+                    _logger.LogWarning("Pairing message for {DeviceName} did not contain a usable token.", deviceName);
+                    return;
+                }
+
+                // The firmware publishes parent_name = its own device name (the topic's device
+                // segment), and HandleSensorConfig stores that value as ParentName on created
+                // sensors. Reusing the topic segment here therefore matches the ParentName
+                // persisted in the API database.
+                var parentName = deviceName;
+
+                _logger.LogInformation("Received pairing token for {DeviceName}, claiming via API.", deviceName);
+                await ClaimPairingTokenAsync(token, parentName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error handling pairing message for {DeviceName}.", deviceName);
+            }
+        }
+
+        private async Task ClaimPairingTokenAsync(string token, string parentName)
+        {
+            try
+            {
+                var client = CreateApiClient();
+
+                for (var attempt = 1; attempt <= PairingClaimMaxRetries + 1; attempt++)
+                {
+                    var response = await HttpJson.PostJsonAsync(client, $"{_apiBaseUrl}/api/pairing/claim", new { token, parentName });
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var responseContent = await response.Content.ReadAsStringAsync();
+                        PairingClaimResponse? result = null;
+                        try
+                        {
+                            result = JsonSerializer.Deserialize<PairingClaimResponse>(responseContent, JsonOptions);
+                        }
+                        catch (JsonException ex)
+                        {
+                            _logger.LogWarning(ex, "Could not deserialize pairing claim response for {ParentName}.", parentName);
+                        }
+
+                        _logger.LogInformation(
+                            "Claimed pairing token for {ParentName}: {SensorCount} sensors, {SwitchCount} switches, {SkippedCount} skipped.",
+                            parentName,
+                            result?.ClaimedSensorIds?.Count ?? 0,
+                            result?.ClaimedSwitchIds?.Count ?? 0,
+                            result?.Skipped ?? 0);
+                        return;
+                    }
+
+                    if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                    {
+                        // Retryable: the device's config messages may still be in flight, so the
+                        // API may not have created sensor/switch rows for this parent yet.
+                        if (attempt <= PairingClaimMaxRetries)
+                        {
+                            _logger.LogInformation(
+                                "No devices found yet for {ParentName} (attempt {Attempt}/{MaxAttempts}), retrying in {Delay}...",
+                                parentName, attempt, PairingClaimMaxRetries + 1, PairingClaimRetryDelay);
+                            await Task.Delay(PairingClaimRetryDelay);
+                            continue;
+                        }
+
+                        var notFoundError = await response.Content.ReadAsStringAsync();
+                        _logger.LogError(
+                            "Giving up claiming pairing token for {ParentName} after {Attempts} attempts: StatusCode={StatusCode}, Response={Error}",
+                            parentName, attempt, response.StatusCode, notFoundError);
+                        return;
+                    }
+
+                    if (response.StatusCode == System.Net.HttpStatusCode.BadRequest ||
+                        response.StatusCode == System.Net.HttpStatusCode.Gone)
+                    {
+                        var invalidError = await response.Content.ReadAsStringAsync();
+                        _logger.LogWarning(
+                            "Pairing token for {ParentName} was rejected as invalid, expired or already consumed: StatusCode={StatusCode}, Response={Error}",
+                            parentName, response.StatusCode, invalidError);
+                        return;
+                    }
+
+                    var error = await response.Content.ReadAsStringAsync();
+                    _logger.LogError(
+                        "Failed to claim pairing token for {ParentName}: StatusCode={StatusCode}, Response={Error}",
+                        parentName, response.StatusCode, error);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error claiming pairing token for {ParentName}.", parentName);
             }
         }
 

--- a/garge-operator.Tests/MqttServicePairingTokenTests.cs
+++ b/garge-operator.Tests/MqttServicePairingTokenTests.cs
@@ -1,0 +1,86 @@
+using garge_operator.Services;
+using Xunit;
+
+namespace garge_operator.Tests;
+
+/// <summary>
+/// Tests the pairing payload parsing in <see cref="MqttService.TryParsePairingToken"/>: the
+/// firmware normally publishes JSON of the form {"token":"ABC123"}, but a plain-string payload
+/// is tolerated by treating the trimmed payload itself as the token.
+/// </summary>
+public class MqttServicePairingTokenTests
+{
+    [Fact]
+    public void JsonPayload_ReturnsToken()
+    {
+        var result = MqttService.TryParsePairingToken("{\"token\":\"ABC123\"}", out var token);
+
+        Assert.True(result);
+        Assert.Equal("ABC123", token);
+    }
+
+    [Fact]
+    public void JsonPayload_TokenIsTrimmed()
+    {
+        var result = MqttService.TryParsePairingToken("{\"token\":\" ABC123 \"}", out var token);
+
+        Assert.True(result);
+        Assert.Equal("ABC123", token);
+    }
+
+    [Fact]
+    public void JsonPayload_MissingToken_ReturnsFalse()
+    {
+        var result = MqttService.TryParsePairingToken("{}", out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void JsonPayload_NullToken_ReturnsFalse()
+    {
+        var result = MqttService.TryParsePairingToken("{\"token\":null}", out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void JsonPayload_EmptyToken_ReturnsFalse()
+    {
+        var result = MqttService.TryParsePairingToken("{\"token\":\"\"}", out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void PlainStringPayload_ReturnsTrimmedPayloadAsToken()
+    {
+        var result = MqttService.TryParsePairingToken(" ABC123\n", out var token);
+
+        Assert.True(result);
+        Assert.Equal("ABC123", token);
+    }
+
+    [Fact]
+    public void EmptyPayload_ReturnsFalse()
+    {
+        var result = MqttService.TryParsePairingToken(string.Empty, out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void WhitespacePayload_ReturnsFalse()
+    {
+        var result = MqttService.TryParsePairingToken("   ", out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void RetryConstantsMatchSpec()
+    {
+        Assert.Equal(5, MqttService.PairingClaimMaxRetries);
+        Assert.Equal(TimeSpan.FromSeconds(3), MqttService.PairingClaimRetryDelay);
+    }
+}


### PR DESCRIPTION
Part of the device-pairing feature (companion PRs in firmware, garge-api, garge-app).

- Subscribes `garge/devices/+/pairing`; parses `{"token":...}` (tolerates plain-string payload).
- Calls `POST /api/pairing/claim` with the topic's device segment as `parentName` (identical to the ParentName stored at sensor creation). Retries 5x3s on retryable 404, stops on 400/410.
- Adds `Mqtt:AllowUntrustedCertificates` (default off) — local-dev escape hatch for TLS-intercepting antivirus.
